### PR TITLE
Fallback if there is no sdk version available from the device properties

### DIFF
--- a/gradle-android-command-plugin/src/main/groovy/com/novoda/gradle/command/Device.groovy
+++ b/gradle-android-command-plugin/src/main/groovy/com/novoda/gradle/command/Device.groovy
@@ -12,7 +12,12 @@ public class Device {
     }
 
     Integer sdkVersion() {
-        deviceProperty('ro.build.version.sdk').toInteger()
+        try {
+            deviceProperty('ro.build.version.sdk').toInteger()
+        } catch (NumberFormatException nfe) {
+            0
+        }
+
     }
 
     String androidVersion() {


### PR DESCRIPTION
Added fallback if there is no sdk version available from the device properties.
