### PR TITLE
Fix import issues

### DIFF
--- a/gradle-android-command-plugin/build.gradle
+++ b/gradle-android-command-plugin/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'signing'
 
 dependencies {
     compile gradleApi()
-    groovy localGroovy()
+    compile localGroovy()
 }
 
 group = 'com.novoda'

--- a/gradle-android-command-plugin/src/main/groovy/com/novoda/gradle/command/AndroidCommandPluginExtension.groovy
+++ b/gradle-android-command-plugin/src/main/groovy/com/novoda/gradle/command/AndroidCommandPluginExtension.groovy
@@ -1,5 +1,4 @@
 package com.novoda.gradle.command
-
 import org.gradle.api.Project
 
 public class AndroidCommandPluginExtension {
@@ -16,6 +15,11 @@ public class AndroidCommandPluginExtension {
     AndroidCommandPluginExtension(Project project) {
         this.project = project
         androidHome = readSdkDirFromLocalProperties() ?: System.env.ANDROID_HOME
+        if (androidHome == null) {
+            throw new IllegalStateException("${System.env.ANDROID_HOME} -- ${System.env} - Couldn't read the SDK directory. If you're running the tests, " +
+                    "make sure you set the ANDROID_HOME env. variable and it points to your Android SDK home. Otherwise, " +
+                    "make sure there's a local.properties in the root of your project with the property sdk.dir pointing to the Android SDK")
+        }
     }
 
     def task(String name, Class<? extends AdbTask> type, Closure configuration) {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Jul 30 18:09:57 CEST 2014
+#Wed Oct 29 15:05:37 GMT 2014
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-1.12-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.1-all.zip


### PR DESCRIPTION
This small PR fixes some build and compile issues.

Moreover, if we don't find `androidHome` we throw an `IllegalStateException`. 
