### PR TITLE
fix tests

### DIFF
--- a/gradle-android-command-plugin/src/test/groovy/com/novoda/gradle/command/AndroidCommandPluginExtensionTest.groovy
+++ b/gradle-android-command-plugin/src/test/groovy/com/novoda/gradle/command/AndroidCommandPluginExtensionTest.groovy
@@ -15,7 +15,7 @@ class AndroidCommandPluginExtensionTest extends GroovyTestCase {
     }
 
     private AndroidCommandPluginExtension createExtension() {
-	def projectDir = new File('.')
+	def projectDir = new File('..')
         def project = ProjectBuilder.builder().withProjectDir(projectDir).build()
         def extension = new AndroidCommandPluginExtension(project)
         extension

--- a/gradle-android-command-plugin/src/test/groovy/com/novoda/gradle/command/AndroidCommandPluginExtensionTest.groovy
+++ b/gradle-android-command-plugin/src/test/groovy/com/novoda/gradle/command/AndroidCommandPluginExtensionTest.groovy
@@ -15,8 +15,10 @@ class AndroidCommandPluginExtensionTest extends GroovyTestCase {
     }
 
     private AndroidCommandPluginExtension createExtension() {
-        def project = ProjectBuilder.builder().build()
+	def projectDir = new File('.')
+        def project = ProjectBuilder.builder().withProjectDir(projectDir).build()
         def extension = new AndroidCommandPluginExtension(project)
         extension
     }
 }
+


### PR DESCRIPTION
The tests were breaking when `ANDROID_HOME` was not set, since `local.properties` could not be found in the tests.

In this PR we explicitly set the root of the project that is injected in the tests to the root module dir, such that it can find a `local.properties` file there.