### PR TITLE
File handling

### DIFF
--- a/gradle-android-command-plugin/src/main/groovy/com/novoda/gradle/command/AdbCommand.groovy
+++ b/gradle-android-command-plugin/src/main/groovy/com/novoda/gradle/command/AdbCommand.groovy
@@ -1,7 +1,6 @@
 package com.novoda.gradle.command
 
-
-public class AdbCommand {
+class AdbCommand {
 
     def adb
     def deviceId

--- a/gradle-android-command-plugin/src/main/groovy/com/novoda/gradle/command/Device.groovy
+++ b/gradle-android-command-plugin/src/main/groovy/com/novoda/gradle/command/Device.groovy
@@ -1,11 +1,12 @@
 package com.novoda.gradle.command
+
 import groovy.transform.Immutable
 
 @Immutable
-public class Device {
+class Device {
 
-    final String adb
-    final String id
+    String adb
+    String id
 
     Integer sdkVersion() {
         try {
@@ -13,7 +14,6 @@ public class Device {
         } catch (NumberFormatException ignored) {
             0
         }
-
     }
 
     String androidVersion() {

--- a/gradle-android-command-plugin/src/main/groovy/com/novoda/gradle/command/Device.groovy
+++ b/gradle-android-command-plugin/src/main/groovy/com/novoda/gradle/command/Device.groovy
@@ -1,15 +1,11 @@
 package com.novoda.gradle.command
+import groovy.transform.Immutable
 
-
+@Immutable
 public class Device {
 
     final String adb
     final String id
-
-    Device(String adb, String id) {
-        this.adb = adb
-        this.id = id
-    }
 
     Integer sdkVersion() {
         try {

--- a/gradle-android-command-plugin/src/main/groovy/com/novoda/gradle/command/FileInfo.groovy
+++ b/gradle-android-command-plugin/src/main/groovy/com/novoda/gradle/command/FileInfo.groovy
@@ -1,0 +1,54 @@
+package com.novoda.gradle.command
+
+import groovy.transform.ToString
+
+@ToString
+public class FileInfo {
+    static enum Type {
+        FILE, DIRECTORY, LINK
+    }
+
+    String name
+    String path
+    Type type
+    Date timestamp
+
+    static FileInfo fromListing(final String line, String dir) {
+        String[] items = line.split()
+        FileInfo.Type type = computeType(items[0])
+        String name = computeName(items, type)
+        Date date = computeTimestamp(items, type)
+        new FileInfo([type: type, name: name, path: dir, timestamp: date])
+    }
+
+    private static String computeName(final String[] lineItems, final FileInfo.Type type) {
+        switch (type) {
+            case Type.LINK:
+                return lineItems[-3]
+            default:
+                return lineItems[-1]
+        }
+    }
+
+    private static Type computeType(final String accessFlags) {
+        if (accessFlags.startsWith("l"))
+            return Type.LINK
+        if (accessFlags.startsWith("d"))
+            return Type.DIRECTORY
+        return Type.FILE
+    }
+
+    private static Date computeTimestamp(String[] items, Type type) {
+        switch (type) {
+            case Type.FILE:
+                return computeTimestamp(items[4], items[5])
+            default:
+                return computeTimestamp(items[3], items[4])
+        }
+    }
+
+    private static Date computeTimestamp(String date, String time) {
+        Date.parse('yyyy-MM-dd HH:mm', date + ' ' + time)
+    }
+
+}

--- a/gradle-android-command-plugin/src/main/groovy/com/novoda/gradle/command/FileInfo.groovy
+++ b/gradle-android-command-plugin/src/main/groovy/com/novoda/gradle/command/FileInfo.groovy
@@ -3,7 +3,7 @@ package com.novoda.gradle.command
 import groovy.transform.Immutable
 
 @Immutable
-public class FileInfo {
+class FileInfo {
     static enum Type {
         FILE, DIRECTORY, LINK
     }

--- a/gradle-android-command-plugin/src/main/groovy/com/novoda/gradle/command/FileInfo.groovy
+++ b/gradle-android-command-plugin/src/main/groovy/com/novoda/gradle/command/FileInfo.groovy
@@ -1,8 +1,8 @@
 package com.novoda.gradle.command
 
-import groovy.transform.ToString
+import groovy.transform.Immutable
 
-@ToString
+@Immutable
 public class FileInfo {
     static enum Type {
         FILE, DIRECTORY, LINK

--- a/gradle-android-command-plugin/src/main/groovy/com/novoda/gradle/command/Files.groovy
+++ b/gradle-android-command-plugin/src/main/groovy/com/novoda/gradle/command/Files.groovy
@@ -1,0 +1,48 @@
+package com.novoda.gradle.command
+
+import org.gradle.api.tasks.TaskAction
+
+class Files extends AdbTask {
+
+    Closure script
+
+    List<FileInfo> list(String dir) {
+        def infos = new ArrayList<FileInfo>()
+        ls(dir).eachLine { line -> infos.add(FileInfo.fromListing(line, dir)) }
+        return infos
+    }
+
+    String isDir(String value) {
+        adb('shell', '[ -d ' + value + ' ] && echo "true"')
+    }
+
+    String push(String source, String target) {
+        adb('push', source, target)
+    }
+
+    String pull(String source, String target) {
+        adb('pull', source, target)
+    }
+
+    String ls(String dir) {
+        shell('ls -la', dir)
+    }
+
+    private String adb(String... params) {
+        AdbCommand adbCommand = [adb: pluginEx.getAdb(), deviceId: getDeviceId(), parameters: Arrays.asList(params) ]
+        adbCommand.execute().text
+    }
+
+    private String shell(... values) {
+        def parameters = ['shell']
+        parameters.addAll(values)
+        AdbCommand adbCommand = [adb: pluginEx.getAdb(), deviceId: getDeviceId(), parameters: parameters]
+        adbCommand.execute().text
+    }
+
+    @TaskAction
+    void exec() {
+        assertDeviceConnected()
+        script.call()
+    }
+}

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -130,18 +130,15 @@ task syncPhotos(type: com.novoda.gradle.command.Files) {
         def backupDir = file('motoPhoto')
         backupDir.mkdir()
         def archivedImageFiles = backupDir.listFiles()
-        def newestTimestamp = archivedImageFiles ? archivedImageFiles?.sort({-it.lastModified()})?.head()?.lastModified() : 0
-        def startDate = new Date(newestTimestamp)
-        println startDate
+
         list(deviceImageDir).findAll { item ->
-            item.timestamp.after(startDate)
-        }
-        .findAll { item ->
             item.name.endsWith('jpg') && !item.name.contains(':nopm:') 
         }
         .each { item ->
-            println item
-            pull item.path + item.name, backupDir.path
+            if (!new File(backupDir.path, item.name).exists()) {
+                println item
+                pull item.path + item.name, backupDir.path
+            }
         }
     }
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -136,7 +136,7 @@ task syncPhotos(type: com.novoda.gradle.command.Files) {
             if (item.timestamp.after(startDate)) {
                 if (item.name.endsWith('jpg') && !item.name.contains(':nopm:'))  {
                     println item
-                    pull item.path + item.name, 'urlaub'
+                    pull item.path + item.name, 'motoPhoto'
                 }
             }
         }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -112,28 +112,36 @@ android {
     }
 }
 
+/**
+* Uses the Files task type to backup sync photos an the device to
+* some local directory.
+* Only pulls files that are newer than the ones already backed up.
+*/
 task syncPhotos(type: com.novoda.gradle.command.Files) {
     deviceId {
-        def moto = android.command.devices().grep({ it.brand() == 'motorola' })
+        def moto = android.command.devices().find ({ it.brand() == 'motorola' })
         if (!moto) {
             throw new GroovyRuntimeException('No Motorola device found')
         }
-        moto[0].id
+        moto.id
     }
     script {
-        def dir = '/sdcard/DCIM/Camera/'
-        def imageDir = file('motoPhoto')
-        imageDir.mkdir()
-        def archivedImageFiles = imageDir.listFiles()
+        def deviceImageDir = '/sdcard/DCIM/Camera/'
+        def backupDir = file('motoPhoto')
+        backupDir.mkdir()
+        def archivedImageFiles = backupDir.listFiles()
         def newestTimestamp = archivedImageFiles ? archivedImageFiles?.sort({-it.lastModified()})?.head()?.lastModified() : 0
         def startDate = new Date(newestTimestamp)
-        list(dir).each { com.novoda.gradle.command.FileInfo item ->
-            if (item.timestamp.after(startDate)) {
-                if (item.name.endsWith('jpg') && !item.name.contains(':nopm:'))  {
-                    println item
-                    pull item.path + item.name, imageDir.path
-                }
-            }
+        println startDate
+        list(deviceImageDir).findAll { item ->
+            item.timestamp.after(startDate)
+        }
+        .findAll { item ->
+            item.name.endsWith('jpg') && !item.name.contains(':nopm:') 
+        }
+        .each { item ->
+            println item
+            pull item.path + item.name, backupDir.path
         }
     }
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -128,7 +128,6 @@ task syncPhotos(type: com.novoda.gradle.command.Files) {
     script {
         def deviceImageDir = '/sdcard/DCIM/Camera/'
         def backupDir = mkdir('motoPhoto')
-        def archivedImageFiles = backupDir.listFiles()
 
         list(deviceImageDir).findAll { image ->
             image.name.endsWith('jpg') && !image.name.contains(':nopm:') 

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -94,7 +94,7 @@ android {
         task('runNewest', com.novoda.gradle.command.Run, ['installDevice']) {
             deviceId {
                 def device = devices().max { it.sdkVersion() }
-	    }
+            }
         }
 
         task autoLogin(type: com.novoda.gradle.command.Input) {
@@ -102,9 +102,9 @@ android {
                 2.times {
                     text 'bob'
                     enter()
-		}
-		enter()
-	    }
+                }
+                enter()
+            }
         }
 
         task listDevices << {
@@ -118,11 +118,19 @@ android {
 }
 
 task syncPhotos(type: com.novoda.gradle.command.Files) {
+    deviceId {
+        def moto = android.command.devices().grep({ it.brand() == 'motorola' })
+        if (!moto) {
+            throw new GroovyRuntimeException('No Motorola device found')
+        }
+        moto[0].id
+    }
     script {
         def dir = '/sdcard/DCIM/Camera/'
-        def imageDir = new File('urlaub')
+        def imageDir = new File('motoPhoto')
         imageDir.mkdir()
-        def newestTimestamp = imageDir.listFiles()?.sort({-it.lastModified()})?.head()?.lastModified()
+        def archivedImageFiles = imageDir.listFiles()
+        def newestTimestamp = archivedImageFiles ? archivedImageFiles?.sort({-it.lastModified()})?.head()?.lastModified() : 0
         def startDate = new Date(newestTimestamp)
         list(dir).each { com.novoda.gradle.command.FileInfo item ->
             if (item.timestamp.after(startDate)) {

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -113,9 +113,9 @@ android {
 }
 
 /**
-* Uses the Files task type to backup sync photos an the device to
+* Uses the Files task type to backup photos on the device to
 * some local directory.
-* Only pulls files that are newer than the ones already backed up.
+* Only pulls files that are not yet backed up.
 */
 task syncPhotos(type: com.novoda.gradle.command.Files) {
     deviceId {

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -133,11 +133,12 @@ task syncPhotos(type: com.novoda.gradle.command.Files) {
         list(deviceImageDir).findAll { image ->
             image.name.endsWith('jpg') && !image.name.contains(':nopm:') 
         }
+        .findAll { image -> 
+            !new File(backupDir.path, image.name).exists() 
+        }
         .each { image ->
-            if (!new File(backupDir.path, image.name).exists()) {
-                println image
-                pull image.path + image.name, backupDir.path
-            }
+            println image
+            pull image.path + image.name, backupDir.path
         }
     }
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -130,13 +130,13 @@ task syncPhotos(type: com.novoda.gradle.command.Files) {
         def backupDir = mkdir('motoPhoto')
         def archivedImageFiles = backupDir.listFiles()
 
-        list(deviceImageDir).findAll { item ->
-            item.name.endsWith('jpg') && !item.name.contains(':nopm:') 
+        list(deviceImageDir).findAll { image ->
+            image.name.endsWith('jpg') && !image.name.contains(':nopm:') 
         }
-        .each { item ->
-            if (!new File(backupDir.path, item.name).exists()) {
-                println item
-                pull item.path + item.name, backupDir.path
+        .each { image ->
+            if (!new File(backupDir.path, image.name).exists()) {
+                println image
+                pull image.path + image.name, backupDir.path
             }
         }
     }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -77,7 +77,7 @@ android {
 
         task('runAmazon', com.novoda.gradle.command.Run) {
             deviceId {
-                def kindle = devices().find({ it.brand() == 'Amazon' })
+                def kindle = devices().find { it.brand() == 'Amazon' }
                 if (!kindle) {
                     throw new GroovyRuntimeException('No Amazon device found')
                 }
@@ -119,7 +119,7 @@ android {
 */
 task syncPhotos(type: com.novoda.gradle.command.Files) {
     deviceId {
-        def moto = android.command.devices().find ({ it.brand() == 'motorola' })
+        def moto = android.command.devices().find { it.brand() == 'motorola' }
         if (!moto) {
             throw new GroovyRuntimeException('No Motorola device found')
         }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -88,6 +88,7 @@ android {
         task('runNewest', com.novoda.gradle.command.Run, ['installDevice']) {
             deviceId {
                 def device = devices().max { it.sdkVersion() }
+                device.id
             }
         }
 

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -121,7 +121,7 @@ task syncPhotos(type: com.novoda.gradle.command.Files) {
     }
     script {
         def dir = '/sdcard/DCIM/Camera/'
-        def imageDir = new File('motoPhoto')
+        def imageDir = file('motoPhoto')
         imageDir.mkdir()
         def archivedImageFiles = imageDir.listFiles()
         def newestTimestamp = archivedImageFiles ? archivedImageFiles?.sort({-it.lastModified()})?.head()?.lastModified() : 0
@@ -130,7 +130,7 @@ task syncPhotos(type: com.novoda.gradle.command.Files) {
             if (item.timestamp.after(startDate)) {
                 if (item.name.endsWith('jpg') && !item.name.contains(':nopm:'))  {
                     println item
-                    pull item.path + item.name, 'motoPhoto'
+                    pull item.path + item.name, imageDir.path
                 }
             }
         }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -64,11 +64,11 @@ android {
     command {
         deviceId {
             def apiLevel = defaultConfig.minSdkVersion.getApiLevel()
-            def minSdkDevices = devices().grep { it.sdkVersion() >= apiLevel }
-            if (!minSdkDevices) {
+            def minSdkDevice = devices().find { it.sdkVersion() >= apiLevel }
+            if (!minSdkDevice) {
                 throw new IllegalStateException('No device found running android version >= ' + apiLevel)
             }
-            minSdkDevices[0].id
+            minSdkDevice.id
         }
 
         events 1000
@@ -77,11 +77,11 @@ android {
 
         task('runAmazon', com.novoda.gradle.command.Run) {
             deviceId {
-                def kindles = devices().grep({ it.brand() == 'Amazon' })
-                if (!kindles) {
+                def kindle = devices().find({ it.brand() == 'Amazon' })
+                if (!kindle) {
                     throw new GroovyRuntimeException('No Amazon device found')
                 }
-                kindles[0].id
+                kindle.id
             }
         }
 

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -8,7 +8,8 @@ buildscript {
 //        classpath 'com.novoda:gradle-android-command-plugin:1.2.1'
     }
 }
-apply plugin: 'android'
+apply plugin: 'com.android.application'
+// apply android-command AFTER android plugin
 apply plugin: 'android-command'
 
 repositories {
@@ -24,7 +25,7 @@ android {
         versionName 'v0.0.1'
 
         minSdkVersion 14
-        targetSdkVersion 19
+        targetSdkVersion 20
     }
 
     buildTypes {
@@ -54,68 +55,99 @@ android {
         }
     }
 
-    // change APK name to include the version name
-    applicationVariants.all { variant ->
-        def file = variant.packageApplication.outputFile
-        variant.packageApplication.outputFile = new File(file.parent, file.name.replace(".apk", "-" + defaultConfig.versionName + ".apk"))
+    command {
+//        deviceId = devices().max{it.sdkVersion()}.id
+        deviceId {
+            devices().grep { it.brand() == 'motorola' }?.head().id
+        }
+//        deviceId = devices().grep { it.brand() == 'hudl' }.head().id
+
+//        events 1000
+
+        task('runAmazon', com.novoda.gradle.command.Run) {
+            deviceId {
+                def kindles = devices().grep({ it.brand() == 'Amazon' })
+                if (!kindles) {
+                    throw new GroovyRuntimeException('No Amazon device found')
+                }
+                kindles[0].id
+            }
+        }
+
+//        task('runNewest', com.novoda.gradle.command.Run, ['installDevice']) {
+//            deviceId = devices().max({ it.sdkVersion() })?.id
+//        }
+//
+//        task('bigMonkey', com.novoda.gradle.command.Monkey, ['installDevice']) {
+//            events {
+//                if (devices().grep { it.id == deviceId }[0].brand() != 'Amazon')
+//                    return 2222
+//                return 5000
+//            }
+//        }
+
+        sortBySubtasks false
+
     }
 
-    command {
-        deviceId {
-            def minSdkDevices = devices().grep({ it.sdkVersion() >= defaultConfig.minSdkVersion.getApiLevel() }).sort()
-            if (!minSdkDevices) {
-                throw new IllegalStateException('No device found running android version >= ' + defaultConfig.minSdkVersion)
-            }
-            minSdkDevices[0].id
+}
+
+
+task autoLogin(type: com.novoda.gradle.command.Input) {
+    script {
+        2.times {
+            text 'bob'
+            enter()
         }
+        enter()
+    }
+}
 
-        events 1000
 
-        task('instHudl', com.novoda.gradle.command.Install) {
-            deviceId {
-                def hudlDevices = devices().grep({ it.brand() == 'hudl' })
-                if (!hudlDevices) {
-                    throw new GroovyRuntimeException('No hudl device found')
+task syncPhotos(type: com.novoda.gradle.command.Files) {
+    script {
+        def dir = '/sdcard/DCIM/Camera/'
+        def imageDir = new File('urlaub')
+        imageDir.mkdir()
+        def newestTimestamp = imageDir.listFiles()?.sort({-it.lastModified()})?.head()?.lastModified()
+        def startDate = new Date(newestTimestamp)
+        list(dir).each { com.novoda.gradle.command.FileInfo item ->
+            if (item.timestamp.after(startDate)) {
+                if (item.name.endsWith('jpg') && !item.name.contains(':nopm:'))  {
+                    println item
+                    pull item.path + item.name, 'urlaub'
                 }
-                hudlDevices[0].id
             }
         }
+    }
+}
 
-        task('runNewest', com.novoda.gradle.command.Run, ['installDevice']) {
-            deviceId {
-                def device = devices().max({ it.sdkVersion() })
-                if (!device) {
-                    throw new GroovyRuntimeException('No device found')
-                }
-                device.id
-            }
-        }
+task listDevices << {
+    println()
+    println "Attached devices:"
+    android.command.devices().grep { it.sdkVersion() >= 14 }.each {
+        println(it.manufacturer() + " " + it.brand() + " " + it.model() + " " + it.id)
+    }
+}
 
-        task('bigMonkey', com.novoda.gradle.command.Monkey, ['installDevice']) {
-            events {
-                if (devices().grep { it.id == deviceId }[0].brand() != 'Amazon')
-                    return 2222
-                return 5000
-            }
-        }
+task runAndLogin(dependsOn: [autoLogin])
 
-        task('autoLogin', type: com.novoda.gradle.command.Input) {
-            script {
-                2.times {
-                    text 'bob'
-                    enter()
-                }
-                enter()
-            }
-        }
+afterEvaluate {
+    runAndLogin.dependsOn 'runFreeBetaDebug'
+    autoLogin.mustRunAfter 'runFreeBetaDebug'
+}
 
-        task('listDevices') << {
-            println()
-            println "Attached devices:"
-            android.command.devices().grep { it.sdkVersion() >= 14 }.each {
-                println(it.manufacturer() + " " + it.model())
-            }
+tasks.addRule('login') { String taskname ->
+    if (taskname.startsWith("loginrun")) {
+        task(taskname, dependsOn: [autoLogin, taskname - "login"])
+        autoLogin.mustRunAfter taskname - "login"
+    }
+}
+
+tasks.addRule("Pattern: ping<ID>") { String taskName ->
+    if (taskName.startsWith("ping")) {
+        task(taskName) << {
+            println "Pinging: " + (taskName - 'ping')
         }
-        sortBySubtasks false
     }
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -127,8 +127,7 @@ task syncPhotos(type: com.novoda.gradle.command.Files) {
     }
     script {
         def deviceImageDir = '/sdcard/DCIM/Camera/'
-        def backupDir = file('motoPhoto')
-        backupDir.mkdir()
+        def backupDir = mkdir('motoPhoto')
         def archivedImageFiles = backupDir.listFiles()
 
         list(deviceImageDir).findAll { item ->

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -57,12 +57,6 @@ android {
 
     // change APK name to include the version name
     applicationVariants.all { variant ->
-        def file = variant.packageApplication.outputFile
-        variant.packageApplication.outputFile = new File(file.parent, file.name.replace(".apk", "-" + defaultConfig.versionName + ".apk"))
-    }
-
-    // change APK name to include the version name
-    applicationVariants.all { variant ->
         def file = variant.outputs[0].packageApplication.outputFile
         variant.outputs[0].packageApplication.outputFile = new File(file.parent, file.name.replace(".apk", "-" + defaultConfig.versionName + ".apk"))
     }


### PR DESCRIPTION
Adds a `Files` task type that introduces basic adb push/pull functionality.

This allows task definitions like
```
task syncPhotos(type: com.novoda.gradle.command.Files) {
    script {
        def dir = '/sdcard/DCIM/Camera/'
        def imageDir = file('backup')
        imageDir.mkdir()
        list(dir).each { item ->
             pull item.path + item.name, imageDir.path
        }
    }
}
```
to pull files off the device. Similar for push onto the device.