### PR TITLE
Add support for specifying a seed for the monkey command

### DIFF
--- a/gradle-android-command-plugin/src/main/groovy/com/novoda/gradle/command/AndroidCommandPlugin.groovy
+++ b/gradle-android-command-plugin/src/main/groovy/com/novoda/gradle/command/AndroidCommandPlugin.groovy
@@ -15,7 +15,7 @@ public class AndroidCommandPlugin implements Plugin<Project> {
         def extension = project.android.extensions.create("command", AndroidCommandPluginExtension, project)
         extension.task 'installDevice', 'installs the APK on the specified device', Install, ['assemble']
         extension.task 'run', 'installs and runs a APK on the specified device', Run, ['installDevice']
-        extension.task 'monkey', 'calls the monkeyrunner on the specified device', Monkey, ['installDevice']
+        extension.task 'monkey', 'calls the monkey command on the specified device', Monkey, ['installDevice']
         extension.task 'clearPrefs', 'clears the shared preferences on the specified device', ClearPreferences
         extension.task 'uninstallDevice', 'uninstalls the APK from the specific device', Uninstall
     }

--- a/gradle-android-command-plugin/src/main/groovy/com/novoda/gradle/command/AndroidCommandPluginExtension.groovy
+++ b/gradle-android-command-plugin/src/main/groovy/com/novoda/gradle/command/AndroidCommandPluginExtension.groovy
@@ -8,6 +8,7 @@ public class AndroidCommandPluginExtension {
     def aapt
     def deviceId
     def events
+    def seed
     def sortBySubtasks
 
     private final Project project
@@ -72,6 +73,10 @@ public class AndroidCommandPluginExtension {
     // prefer system property over direct setting to enable commandline arguments
     def getEvents() {
         System.properties['events'] ?: events ?: 10000
+    }
+
+    def getSeed() {
+        System.properties['seed'] ?: seed
     }
 
     def devices() {

--- a/gradle-android-command-plugin/src/main/groovy/com/novoda/gradle/command/Monkey.groovy
+++ b/gradle-android-command-plugin/src/main/groovy/com/novoda/gradle/command/Monkey.groovy
@@ -30,6 +30,6 @@ class Monkey extends AdbTask {
     private getSeed() {
         if (seed instanceof Closure)
             seed = seed.call()
-        seed ?: pluginEx.getSeed()
+        seed ?: pluginEx.seed
     }
 }

--- a/gradle-android-command-plugin/src/main/groovy/com/novoda/gradle/command/Monkey.groovy
+++ b/gradle-android-command-plugin/src/main/groovy/com/novoda/gradle/command/Monkey.groovy
@@ -5,6 +5,7 @@ import org.gradle.api.tasks.TaskAction
 class Monkey extends AdbTask {
 
     def events
+    def seed
 
     protected handleCommandOutput(def text) {
         super.handleCommandOutput(text)
@@ -14,12 +15,21 @@ class Monkey extends AdbTask {
 
     @TaskAction
     void exec() {
-        assertDeviceAndRunCommand(['shell', 'monkey', '-p', packageName, '-v', getEvents()])
+        def arguments = ['shell', 'monkey', '-p', packageName, '-v', getEvents()]
+        if (getSeed())
+            arguments += ['-s', getSeed()]
+        assertDeviceAndRunCommand(arguments)
     }
 
     private getEvents() {
         if (events instanceof Closure)
             events = events.call()
         events ?: pluginEx.events
+    }
+
+    private getSeed() {
+        if (seed instanceof Closure)
+            seed = seed.call()
+        seed ?: pluginEx.getSeed()
     }
 }

--- a/gradle-android-command-plugin/src/test/groovy/com/novoda/gradle/command/AndroidCommandPluginExtensionTest.groovy
+++ b/gradle-android-command-plugin/src/test/groovy/com/novoda/gradle/command/AndroidCommandPluginExtensionTest.groovy
@@ -14,7 +14,17 @@ class AndroidCommandPluginExtensionTest extends GroovyTestCase {
         assert extension.androidHome != null
     }
 
-    private AndroidCommandPluginExtension createExtension() {
+    void testDefaultEvents() {
+        def extension = createExtension()
+        assert extension.getEvents() == 10000
+    }
+
+    void testDefaultSeed() {
+        def extension = createExtension()
+        assert extension.getSeed() == null
+    }
+
+    private static AndroidCommandPluginExtension createExtension() {
 	def projectDir = new File('..')
         def project = ProjectBuilder.builder().withProjectDir(projectDir).build()
         def extension = new AndroidCommandPluginExtension(project)


### PR DESCRIPTION
This PR allows to specify the seed to run the monkey command with.
This allows to be able to reproduce failing monkey runs for debugging purposes.