### PR TITLE
Use the StopExecutionException to fail on missing android plugin

### DIFF
--- a/gradle-android-command-plugin/src/main/groovy/com/novoda/gradle/command/AndroidCommandPlugin.groovy
+++ b/gradle-android-command-plugin/src/main/groovy/com/novoda/gradle/command/AndroidCommandPlugin.groovy
@@ -1,8 +1,7 @@
 package com.novoda.gradle.command
-
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.ProjectConfigurationException
+import org.gradle.api.tasks.StopExecutionException
 
 public class AndroidCommandPlugin implements Plugin<Project> {
 
@@ -10,7 +9,7 @@ public class AndroidCommandPlugin implements Plugin<Project> {
 
     void apply(Project project) {
         if (!project.plugins.hasPlugin('android')) {
-            throw new ProjectConfigurationException("The 'android' plugin is required.")
+            throw new StopExecutionException("The 'android' plugin is required.")
         }
         def extension = project.android.extensions.create("command", AndroidCommandPluginExtension, project)
         extension.task 'installDevice', 'installs the APK on the specified device', Install, ['assemble']


### PR DESCRIPTION
Fixes #43 