### PR TITLE
Inherit the SDK path from the android plugin

### DIFF
--- a/gradle-android-command-plugin/src/main/groovy/com/novoda/gradle/command/AndroidCommandPlugin.groovy
+++ b/gradle-android-command-plugin/src/main/groovy/com/novoda/gradle/command/AndroidCommandPlugin.groovy
@@ -12,15 +12,15 @@ public class AndroidCommandPlugin implements Plugin<Project> {
             throw new StopExecutionException("The 'android' plugin is required.")
         }
 
-        def android = project.android
+        def androidExtension = project.android
         def androidHome
-        if (android.hasProperty('sdkHandler')) {
-            androidHome = "${android.sdkHandler.sdkFolder}"
+        if (androidExtension.hasProperty('sdkHandler')) {
+            androidHome = "${androidExtension.sdkHandler.sdkFolder}"
         } else {
-            androidHome = "${android.sdkDirectory}"
+            androidHome = "${androidExtension.sdkDirectory}"
         }
 
-        def extension = android.extensions.create("command", AndroidCommandPluginExtension, project, androidHome)
+        def extension = androidExtension.extensions.create("command", AndroidCommandPluginExtension, project, androidHome)
         extension.task 'installDevice', 'installs the APK on the specified device', Install, ['assemble']
         extension.task 'run', 'installs and runs a APK on the specified device', Run, ['installDevice']
         extension.task 'monkey', 'calls the monkey command on the specified device', Monkey, ['installDevice']

--- a/gradle-android-command-plugin/src/main/groovy/com/novoda/gradle/command/AndroidCommandPlugin.groovy
+++ b/gradle-android-command-plugin/src/main/groovy/com/novoda/gradle/command/AndroidCommandPlugin.groovy
@@ -27,8 +27,10 @@ public class AndroidCommandPlugin implements Plugin<Project> {
         def androidHome
         if (androidExtension.hasProperty('sdkHandler')) {
             androidHome = "${androidExtension.sdkHandler.sdkFolder}"
-        } else {
+        } else if(androidExtension.hasProperty('sdkDirectory')) {
             androidHome = "${androidExtension.sdkDirectory}"
+        } else {
+            throw new IllegalStateException('The android plugin is not exposing the SDK folder in an expected way.')
         }
         androidHome
     }

--- a/gradle-android-command-plugin/src/main/groovy/com/novoda/gradle/command/AndroidCommandPlugin.groovy
+++ b/gradle-android-command-plugin/src/main/groovy/com/novoda/gradle/command/AndroidCommandPlugin.groovy
@@ -11,7 +11,16 @@ public class AndroidCommandPlugin implements Plugin<Project> {
         if (!project.plugins.hasPlugin('android')) {
             throw new StopExecutionException("The 'android' plugin is required.")
         }
-        def extension = project.android.extensions.create("command", AndroidCommandPluginExtension, project)
+
+        def android = project.android
+        def androidHome
+        if (android.hasProperty('sdkHandler')) {
+            androidHome = "${android.sdkHandler.sdkFolder}"
+        } else {
+            androidHome = "${android.sdkDirectory}"
+        }
+
+        def extension = android.extensions.create("command", AndroidCommandPluginExtension, project, androidHome)
         extension.task 'installDevice', 'installs the APK on the specified device', Install, ['assemble']
         extension.task 'run', 'installs and runs a APK on the specified device', Run, ['installDevice']
         extension.task 'monkey', 'calls the monkey command on the specified device', Monkey, ['installDevice']

--- a/gradle-android-command-plugin/src/main/groovy/com/novoda/gradle/command/AndroidCommandPlugin.groovy
+++ b/gradle-android-command-plugin/src/main/groovy/com/novoda/gradle/command/AndroidCommandPlugin.groovy
@@ -13,12 +13,7 @@ public class AndroidCommandPlugin implements Plugin<Project> {
         }
 
         def androidExtension = project.android
-        def androidHome
-        if (androidExtension.hasProperty('sdkHandler')) {
-            androidHome = "${androidExtension.sdkHandler.sdkFolder}"
-        } else {
-            androidHome = "${androidExtension.sdkDirectory}"
-        }
+        String androidHome = getAndroidHome(androidExtension)
 
         def extension = androidExtension.extensions.create("command", AndroidCommandPluginExtension, project, androidHome)
         extension.task 'installDevice', 'installs the APK on the specified device', Install, ['assemble']
@@ -26,5 +21,15 @@ public class AndroidCommandPlugin implements Plugin<Project> {
         extension.task 'monkey', 'calls the monkey command on the specified device', Monkey, ['installDevice']
         extension.task 'clearPrefs', 'clears the shared preferences on the specified device', ClearPreferences
         extension.task 'uninstallDevice', 'uninstalls the APK from the specific device', Uninstall
+    }
+
+    private static String getAndroidHome(androidExtension) {
+        def androidHome
+        if (androidExtension.hasProperty('sdkHandler')) {
+            androidHome = "${androidExtension.sdkHandler.sdkFolder}"
+        } else {
+            androidHome = "${androidExtension.sdkDirectory}"
+        }
+        androidHome
     }
 }

--- a/gradle-android-command-plugin/src/main/groovy/com/novoda/gradle/command/AndroidCommandPluginExtension.groovy
+++ b/gradle-android-command-plugin/src/main/groovy/com/novoda/gradle/command/AndroidCommandPluginExtension.groovy
@@ -13,14 +13,9 @@ public class AndroidCommandPluginExtension {
 
     private final Project project
 
-    AndroidCommandPluginExtension(Project project) {
+    AndroidCommandPluginExtension(Project project, def androidHome) {
         this.project = project
-        androidHome = readSdkDirFromLocalProperties() ?: System.env.ANDROID_HOME
-        if (androidHome == null) {
-            throw new IllegalStateException("Couldn't read the SDK directory. If you're running the tests, " +
-                    "make sure you set the ANDROID_HOME env. variable and it points to your Android SDK home. Otherwise, " +
-                    "make sure there's a local.properties in the root of your project with the property sdk.dir pointing to the Android SDK")
-        }
+        this.androidHome = androidHome
     }
 
     def task(String name, Class<? extends AdbTask> type, Closure configuration) {
@@ -102,16 +97,5 @@ public class AndroidCommandPluginExtension {
             throw new IllegalStateException('No attached devices found')
         }
         deviceIds[0]
-    }
-
-    private def readSdkDirFromLocalProperties() {
-        try {
-            Properties properties = new Properties()
-            properties.load(project.rootProject.file('local.properties').newDataInputStream())
-            properties.getProperty('sdk.dir').trim()
-        }
-        catch (Exception e) {
-            project.getLogger().debug("could not read local.properties", e)
-        }
     }
 }

--- a/gradle-android-command-plugin/src/main/groovy/com/novoda/gradle/command/AndroidCommandPluginExtension.groovy
+++ b/gradle-android-command-plugin/src/main/groovy/com/novoda/gradle/command/AndroidCommandPluginExtension.groovy
@@ -3,7 +3,7 @@ import org.gradle.api.Project
 
 public class AndroidCommandPluginExtension {
 
-    def androidHome
+    String androidHome
     def adb
     def aapt
     def deviceId
@@ -13,7 +13,7 @@ public class AndroidCommandPluginExtension {
 
     private final Project project
 
-    AndroidCommandPluginExtension(Project project, def androidHome) {
+    AndroidCommandPluginExtension(Project project, String androidHome) {
         this.project = project
         this.androidHome = androidHome
     }

--- a/gradle-android-command-plugin/src/test/groovy/com/novoda/gradle/command/AndroidCommandPluginExtensionTest.groovy
+++ b/gradle-android-command-plugin/src/test/groovy/com/novoda/gradle/command/AndroidCommandPluginExtensionTest.groovy
@@ -2,11 +2,17 @@ package com.novoda.gradle.command
 import org.gradle.testfixtures.ProjectBuilder
 
 class AndroidCommandPluginExtensionTest extends GroovyTestCase {
+    static private final String SDK_PATH = '/some/path'
 
     void testDefaultAdbPath() {
         def extension = createExtension()
         assert extension.getAdb() != null
         assert extension.getAdb().contains('adb')
+    }
+
+    void testDefaultAndroidHomePath() {
+        def extension = createExtension()
+        assert extension.androidHome == SDK_PATH
     }
 
     void testDefaultEvents() {
@@ -22,7 +28,7 @@ class AndroidCommandPluginExtensionTest extends GroovyTestCase {
     private static AndroidCommandPluginExtension createExtension() {
 	def projectDir = new File('..')
         def project = ProjectBuilder.builder().withProjectDir(projectDir).build()
-        def extension = new AndroidCommandPluginExtension(project, null)
+        def extension = new AndroidCommandPluginExtension(project, SDK_PATH)
         extension
     }
 }

--- a/gradle-android-command-plugin/src/test/groovy/com/novoda/gradle/command/AndroidCommandPluginExtensionTest.groovy
+++ b/gradle-android-command-plugin/src/test/groovy/com/novoda/gradle/command/AndroidCommandPluginExtensionTest.groovy
@@ -2,7 +2,7 @@ package com.novoda.gradle.command
 import org.gradle.testfixtures.ProjectBuilder
 
 class AndroidCommandPluginExtensionTest extends GroovyTestCase {
-    static private final String SDK_PATH = '/some/path'
+    private static final String SDK_PATH = '/some/path'
 
     void testDefaultAdbPath() {
         def extension = createExtension()

--- a/gradle-android-command-plugin/src/test/groovy/com/novoda/gradle/command/AndroidCommandPluginExtensionTest.groovy
+++ b/gradle-android-command-plugin/src/test/groovy/com/novoda/gradle/command/AndroidCommandPluginExtensionTest.groovy
@@ -9,11 +9,6 @@ class AndroidCommandPluginExtensionTest extends GroovyTestCase {
         assert extension.getAdb().contains('adb')
     }
 
-    void testDefaultAndroidHomePath() {
-        def extension = createExtension()
-        assert extension.androidHome != null
-    }
-
     void testDefaultEvents() {
         def extension = createExtension()
         assert extension.getEvents() == 10000
@@ -27,7 +22,7 @@ class AndroidCommandPluginExtensionTest extends GroovyTestCase {
     private static AndroidCommandPluginExtension createExtension() {
 	def projectDir = new File('..')
         def project = ProjectBuilder.builder().withProjectDir(projectDir).build()
-        def extension = new AndroidCommandPluginExtension(project)
+        def extension = new AndroidCommandPluginExtension(project, null)
         extension
     }
 }


### PR DESCRIPTION
The android grade plugin already determines the SDK path and exposes it so it is not needed to duplicate such logic. Unfortunately it is done in different ways in different versions of the android plugin.

The unit test about androidHome is now useless, so it has been removed.