### PR TITLE
Chore/Use plugindev plugin

### DIFF
--- a/gradle-android-command-plugin/build.gradle
+++ b/gradle-android-command-plugin/build.gradle
@@ -1,33 +1,24 @@
-buildscript {
-    repositories {
-        jcenter()
-    }
-    dependencies {
-        classpath 'com.novoda:bintray-release:0.2.4'
-    }
+plugins {
+    id 'nu.studer.plugindev' version '1.0.3'
 }
 
 apply plugin: 'groovy'
-apply plugin: 'bintray-release' 
 
-dependencies {
-    compile gradleApi()
-}
 
 group = 'com.novoda'
-version = "1.4.0"
+version = '1.4.1'
 
-ext {
-    sourceCompatibility = 1.6
-    targetCompatibility = 1.6
-    artifactId = 'gradle-android-command-plugin'
-}
-
-publish {
-    userOrg = 'novoda'
-    groupId = 'com.novoda'
-    artifactId = project.ext.artifactId
-    version = project.version
-    description = 'Useful tasks for gradle android builds'
-    website = 'https://github.com/novoda/gradle-android-command-plugin'
+plugindev {
+    pluginId 'com.novoda.android-command'
+    pluginName 'gradle-andorid-command-plugin'
+    pluginImplementationClass 'com.novoda.gradle.command.AndroidCommandPlugin'
+    pluginDescription 'Useful tasks for gradle android builds'
+    pluginLicenses 'Apache-2.0'
+    pluginTags 'gradle', 'plugin', 'android', 'adb'
+    authorId 'novoda'
+    authorName 'Novoda'
+    authorEmail 'nos@novoda.com'
+    projectUrl 'https://github.com/novoda/gradle-android-command-plugin'
+    projectInceptionYear '2013'
+    done()
 }

--- a/gradle-android-command-plugin/build.gradle
+++ b/gradle-android-command-plugin/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'groovy'
 
 
 group = 'com.novoda'
-version = '1.4.1'
+version = '1.4.0'
 
 plugindev {
     pluginId 'com.novoda.android-command'


### PR DESCRIPTION
This PR replaces the bintray plugin with the plugindev plugin.

It adds the namespaced plugin id com.novoda.android-command. The plugin id android-command is deprecated (and the meta-inf file not deleted)

The plugindev ensure the compatibility of the bintray publication to jcenter, maven central and the gradle plugin portal.
In addition the plugin adds required dependencies for gradle plugin development and generates pom and meta-inf files. It adds also the required [attributes for the gradle plugin portal](https://github.com/etiennestuder/gradle-plugindev-plugin/blob/master/src/main/groovy/nu/studer/gradle/plugindev/PluginDevPlugin.groovy#L291) mentioned in https://github.com/novoda/bintray-release/issues/54. 

Before:

``` xml
<?xml version="1.0" encoding="UTF-8"?>
<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  <modelVersion>4.0.0</modelVersion>
  <groupId>com.novoda</groupId>
  <artifactId>gradle-android-command-plugin</artifactId>
  <version>1.4.0</version>
</project>
```

After:
``` xml
<?xml version="1.0" encoding="UTF-8"?>
<project xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  <modelVersion>4.0.0</modelVersion>
  <groupId>com.novoda</groupId>
  <artifactId>gradle-android-command-plugin</artifactId>
  <version>1.4.1</version>
  <name>gradle-andorid-command-plugin</name>
  <description>Useful tasks for gradle android builds</description>
  <url>https://github.com/novoda/gradle-android-command-plugin</url>
  <inceptionYear>2013</inceptionYear>
  <licenses>
    <license>
      <name>Apache License, Version 2.0</name>
      <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
    </license>
  </licenses>
  <scm>
    <url>https://github.com/novoda/gradle-android-command-plugin.git</url>
  </scm>
  <developers>
    <developer>
      <id>novoda</id>
      <name>Novoda</name>
      <email>nos@novoda.com</email>
    </developer>
  </developers>
</project>
```

