### PR TITLE
Add support for launching activity aliases

### DIFF
--- a/gradle-android-command-plugin/src/main/groovy/com/novoda/gradle/command/AdbTask.groovy
+++ b/gradle-android-command-plugin/src/main/groovy/com/novoda/gradle/command/AdbTask.groovy
@@ -20,16 +20,63 @@ public class AdbTask extends org.gradle.api.DefaultTask {
     }
 
     def getPackageName() {
-        def matcher = readApkProperty('package').readLines()[0] =~ /name='(.*?)'/
-        if (matcher) {
-            matcher[0][1]
+        def output = readApkProperty('package')
+        if (output) {
+            def matcher = output.readLines()[0] =~ /name='(.*?)'/
+            if (matcher) {
+                matcher[0][1]
+            }
+        } else {
+            throw new IllegalArgumentException("Could not read 'package' property of $apkPath")
         }
     }
 
     def getLaunchableActivity() {
-        def matcher = readApkProperty('launchable-activity').readLines()[0] =~ /name='(.*?)'/
-        if (matcher) {
-            matcher[0][1]
+        def output = readApkProperty('launchable-activity')
+        if (output) {
+            def matcher = output.readLines()[0] =~ /name='(.*?)'/
+            if (matcher) {
+                matcher[0][1]
+            }
+        } else {
+            // Fall back to manually parsing aapt's pseudo-XML output to support activity aliases, see
+            // https://code.google.com/p/android/issues/detail?id=157150
+            logger.info 'no launchable-activity found, falling back to parsing the manifest'
+
+            output = [pluginEx.aapt, 'dump', 'xmltree', apkPath, 'AndroidManifest.xml'].execute().text
+
+            def it = output.readLines().iterator()
+            def nextLine = null
+
+            // Look for activity alias definitions.
+            while (it.hasNext()) {
+                def line = nextLine ?: it.next()
+                nextLine = null
+
+                def matcher = line =~ /(\s+)(E: activity-alias)(.*)/
+                if (matcher) {
+                    def intentation = matcher[0][1] + '  '
+                    def name = null, main = false, launcher = false, disabled = false
+                    
+                    // Parse the indented block for the current activity alias.
+                    while (it.hasNext() && (nextLine = it.next()).startsWith(intentation)) {
+                        matcher = nextLine =~ /A: android:name.*="([^"]+)"/
+                        if (matcher && !name) {
+                            name = matcher[0][1]
+                        }
+                        main = main || nextLine.contains('android.intent.action.MAIN')
+                        launcher = launcher || nextLine.contains('android.intent.category.LAUNCHER')
+                        
+                        // Exclude disabled entries.
+                        disabled = disabled || nextLine ==~ /^(\s+)A: android:enabled.*=.*0x0$/
+                    }
+
+                    if (name && main && launcher && !disabled) {
+                        // Return the first enabled activity-alias launcher.
+                        return name
+                    }
+                }
+            }
         }
     }
 
@@ -68,9 +115,6 @@ public class AdbTask extends org.gradle.api.DefaultTask {
         }
         String output = [pluginEx.aapt, 'dump', 'badging', apkPath].execute().text.readLines().find {
             it.startsWith("$propertyKey:")
-        }
-        if (output == null) {
-            throw new IllegalStateException("Could not read property '$propertyKey' of $apkPath")
         }
         output
     }

--- a/gradle-android-command-plugin/src/main/groovy/com/novoda/gradle/command/Install.groovy
+++ b/gradle-android-command-plugin/src/main/groovy/com/novoda/gradle/command/Install.groovy
@@ -6,6 +6,6 @@ class Install extends AdbTask {
 
     @TaskAction
     void exec() {
-        assertDeviceAndRunCommand(['install', '-r', apkPath])
+        assertDeviceAndRunCommand(['install', '-rd', apkPath])
     }
 }

--- a/gradle-android-command-plugin/src/main/groovy/com/novoda/gradle/command/VariantConfigurator.groovy
+++ b/gradle-android-command-plugin/src/main/groovy/com/novoda/gradle/command/VariantConfigurator.groovy
@@ -33,7 +33,7 @@ class VariantConfigurator {
             task.group = AndroidCommandPlugin.TASK_GROUP + " for variant " + variationName;
         }
 
-        task.apkPath = "${-> variant.outputs[0].packageApplication.outputFile}"
+        task.apkPath = "${-> variant.outputs[0].outputFile}"
         if (this.description) {
             task.description = this.description + " for variant ${variationName}"
         }


### PR DESCRIPTION
Unfortunately, aapt does not return a "launchable-activity" property if
the launchable activity is an activity alias. Work around that by manually
parsing aapt's pseudo-XML output.

EDIT: Added two more commits, one to fix issue #74, and one to allow app downgrades when installing.