### PR TITLE
Make the "start" task not depend on "install"

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ The plugin creates new tasks that you can use:
   * `installDevice<Variant>` [`com.novoda.gradle.command.InstallDevice`] - installs the app on a specific device.
   * `uninstallDevice<Variant>` [`com.novoda.gradle.command.UninstallDevice`] - uninstalls the app from a specific device.
   * `run<Variant>` [`com.novoda.gradle.command.Run`] - installs and launches the app on a specific device.
+  * `start<Variant>` [`com.novoda.gradle.command.Run`] - launches the app on a specific device (without installing it).
   * `stop<Variant>` [`com.novoda.gradle.command.Stop`] - Forcibly stops the app on a specific device.
   * `monkey<Variant>` [`com.novoda.gradle.command.Monkey`] - installs and runs monkey on a specific device.
   * `clearPreferences<Variant>` [`com.novoda.gradle.command.ClearPreferences`] - clears app preferences on a specific device.

--- a/gradle-android-command-plugin/src/main/groovy/com/novoda/gradle/command/AndroidCommandPlugin.groovy
+++ b/gradle-android-command-plugin/src/main/groovy/com/novoda/gradle/command/AndroidCommandPlugin.groovy
@@ -18,7 +18,7 @@ public class AndroidCommandPlugin implements Plugin<Project> {
         def extension = androidExtension.extensions.create("command", AndroidCommandPluginExtension, project, androidHome)
         extension.task 'installDevice', 'installs the APK on the specified device', Install, ['assemble']
         extension.task 'run', 'installs and runs a APK on the specified device', Run, ['installDevice']
-        extension.task 'start', 'installs and runs a APK on the specified device (alias for "run")', Run, ['installDevice']
+        extension.task 'start', 'runs an already installed APK on the specified device', Run
         extension.task 'stop', 'forcibly stops the app on the specified device', Stop
         extension.task 'monkey', 'calls the monkey command on the specified device', Monkey, ['installDevice']
         extension.task 'clearPrefs', 'clears the shared preferences on the specified device', ClearPreferences


### PR DESCRIPTION
Add more value to the newly introduced "start" task by not making it a
mere alias for "run". Do not make it depend on "install" in order to more
quickly start an app that you know to already be installed.