### PR TITLE
Feature/add task for Activity Stack

### DIFF
--- a/gradle-android-command-plugin/src/main/groovy/com/novoda/gradle/command/ActivityRecord.groovy
+++ b/gradle-android-command-plugin/src/main/groovy/com/novoda/gradle/command/ActivityRecord.groovy
@@ -1,0 +1,12 @@
+package com.novoda.gradle.command
+
+class ActivityRecord {
+    String index
+    String packageName
+    String activityName
+
+    @Override
+    String toString() {
+        "#$index: $packageName/$activityName"
+    }
+}

--- a/gradle-android-command-plugin/src/main/groovy/com/novoda/gradle/command/ActivityStack.groovy
+++ b/gradle-android-command-plugin/src/main/groovy/com/novoda/gradle/command/ActivityStack.groovy
@@ -1,0 +1,35 @@
+package com.novoda.gradle.command
+
+class ActivityStack extends AdbTask {
+
+    protected handleCommandOutput(def text) {
+        super.handleCommandOutput(text)
+
+        def activityRecords = []
+        text.eachLine { line ->
+            def matcher = line =~ /Run #([0-9]*): ActivityRecord\{\S* \S* ([^\/]*)\/(\S*)/
+            if (matcher) {
+                activityRecords << new ActivityRecord(index:matcher[0][1], packageName:matcher[0][2], activityName:matcher[0][3])
+            }
+        }
+        activityRecords.each {
+            logger.info it.toString()
+        }
+    }
+
+    def getActivityRecords() {
+        def commandLine = ['shell', 'dumpsys', 'activity', '|', 'grep', '-i', 'run']
+        AdbCommand command = [adb: pluginEx.getAdb(), deviceId: getDeviceId(), parameters: commandLine]
+        logger.info "running command: $command"
+        def output = command.execute().text
+
+        def activityRecords = []
+        output.eachLine { line ->
+            def matcher = line =~ /Run #([0-9]*): ActivityRecord\{\S* \S* ([^\/]*)\/(\S*)/
+            if (matcher) {
+                activityRecords << new ActivityRecord(index: matcher[0][1], packageName: matcher[0][2], activityName: matcher[0][3])
+            }
+        }
+        activityRecords
+    }
+}

--- a/gradle-android-command-plugin/src/main/groovy/com/novoda/gradle/command/ActivityStack.groovy
+++ b/gradle-android-command-plugin/src/main/groovy/com/novoda/gradle/command/ActivityStack.groovy
@@ -2,21 +2,6 @@ package com.novoda.gradle.command
 
 class ActivityStack extends AdbTask {
 
-    protected handleCommandOutput(def text) {
-        super.handleCommandOutput(text)
-
-        def activityRecords = []
-        text.eachLine { line ->
-            def matcher = line =~ /Run #([0-9]*): ActivityRecord\{\S* \S* ([^\/]*)\/(\S*)/
-            if (matcher) {
-                activityRecords << new ActivityRecord(index:matcher[0][1], packageName:matcher[0][2], activityName:matcher[0][3])
-            }
-        }
-        activityRecords.each {
-            logger.info it.toString()
-        }
-    }
-
     def getActivityRecords() {
         def commandLine = ['shell', 'dumpsys', 'activity', '|', 'grep', '-i', 'run']
         AdbCommand command = [adb: pluginEx.getAdb(), deviceId: getDeviceId(), parameters: commandLine]

--- a/gradle-android-command-plugin/src/main/groovy/com/novoda/gradle/command/ActivityStack.groovy
+++ b/gradle-android-command-plugin/src/main/groovy/com/novoda/gradle/command/ActivityStack.groovy
@@ -1,6 +1,15 @@
 package com.novoda.gradle.command
 
+import org.gradle.api.tasks.TaskAction
+
 class ActivityStack extends AdbTask {
+
+    @TaskAction
+    void exec() {
+        getActivityRecords().each {
+            println it.toString()
+        }
+    }
 
     def getActivityRecords() {
         def commandLine = ['shell', 'dumpsys', 'activity', '|', 'grep', '-i', 'run']

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -109,6 +109,12 @@ android {
                 println it
             }
         }
+
+        task dumpActivityStack(type: com.novoda.gradle.command.ActivityStack) << {
+            getActivityRecords().each {
+                logger.info it.toString()
+            }
+        }
     }
 }
 

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -110,10 +110,7 @@ android {
             }
         }
 
-        task dumpActivityStack(type: com.novoda.gradle.command.ActivityStack) << {
-            getActivityRecords().each {
-                logger.info it.toString()
-            }
+        task dumpActivityStack(type: com.novoda.gradle.command.ActivityStack) {
         }
     }
 }


### PR DESCRIPTION
This PR adds an ActivityStack task and an new task to the sample dumping the activity stack.

The task is based on `AdbCommand`, however, it does not uses `runCommand` (and not `handleCommandOutput` as tried initially https://github.com/novoda/gradle-android-command-plugin/commit/6c3f45dd7d90f3d581171af209d95ab5c59ce6c8) because `runCommand` does not return anything and the would not have access to the activity stack.

Now users can call `getActivityStack` and perform actions on the stack in their custom task.

The default action is dumping the stack. The output looks like 
```
:sample:dumpActivityStack
#3: com.google.android.gms/.update.SystemUpdateActivity
#2: com.google.android.calculator/com.android.calculator2.Calculator
#1: com.google.android.youtube/com.google.android.apps.youtube.app.WatchWhileActivity
#0: com.android.vending/com.google.android.finsky.activities.MainActivity
#1: com.google.android.googlequicksearchbox/com.google.android.launcher.GEL
#0: com.android.systemui/.recents.RecentsActivity
```