### PR TITLE
Adds a task to disable system animations

### DIFF
--- a/gradle-android-command-plugin/src/main/groovy/com/novoda/gradle/command/AndroidCommandPlugin.groovy
+++ b/gradle-android-command-plugin/src/main/groovy/com/novoda/gradle/command/AndroidCommandPlugin.groovy
@@ -21,6 +21,7 @@ public class AndroidCommandPlugin implements Plugin<Project> {
         extension.task 'run', 'installs and runs a APK on the specified device', Run, ['installDevice']
         extension.task 'start', 'runs an already installed APK on the specified device', Run
         extension.task 'stop', 'forcibly stops the app on the specified device', Stop
+        extension.task 'disableSystemAnimations', 'disables system animations on the specified device', DisableSystemAnimations
         extension.task 'monkey', 'calls the monkey command on the specified device', Monkey, ['installDevice']
         extension.task 'clearPrefs', 'clears the shared preferences on the specified device', ClearPreferences
         extension.task 'uninstallDevice', 'uninstalls the APK from the specific device', Uninstall

--- a/gradle-android-command-plugin/src/main/groovy/com/novoda/gradle/command/AndroidCommandPlugin.groovy
+++ b/gradle-android-command-plugin/src/main/groovy/com/novoda/gradle/command/AndroidCommandPlugin.groovy
@@ -21,8 +21,9 @@ public class AndroidCommandPlugin implements Plugin<Project> {
         extension.task 'run', 'installs and runs a APK on the specified device', Run, ['installDevice']
         extension.task 'start', 'runs an already installed APK on the specified device', Run
         extension.task 'stop', 'forcibly stops the app on the specified device', Stop
-        extension.task 'disableSystemAnimations', 'disables system animations on the specified device', DisableSystemAnimations
         extension.task 'monkey', 'calls the monkey command on the specified device', Monkey, ['installDevice']
+        extension.task 'enableSystemAnimations', 'enables system animations on the specified device', EnableSystemAnimations
+        extension.task 'disableSystemAnimations', 'disables system animations on the specified device', DisableSystemAnimations
         extension.task 'clearPrefs', 'clears the shared preferences on the specified device', ClearPreferences
         extension.task 'uninstallDevice', 'uninstalls the APK from the specific device', Uninstall
     }

--- a/gradle-android-command-plugin/src/main/groovy/com/novoda/gradle/command/DisableSystemAnimations.groovy
+++ b/gradle-android-command-plugin/src/main/groovy/com/novoda/gradle/command/DisableSystemAnimations.groovy
@@ -1,0 +1,30 @@
+package com.novoda.gradle.command
+
+import org.gradle.api.tasks.TaskAction
+
+class DisableSystemAnimations extends AdbTask {
+
+  @TaskAction
+  void exec() {
+    assertDeviceConnected()
+    disableAnimatorDuration()
+    disableTransitionAnimations()
+    disableWindowAnimations()
+  }
+
+  private disableWindowAnimations() {
+    def arguments = ['shell', 'settings', 'put', 'global', 'window_animation_scale', '0']
+    runCommand(arguments)
+  }
+
+  private disableTransitionAnimations() {
+    def arguments = ['shell', 'settings', 'put', 'global', 'transition_animation_scale', '0']
+    runCommand(arguments)
+  }
+
+  private disableAnimatorDuration() {
+    def arguments = ['shell', 'settings', 'put', 'global', 'animator_duration_scale', '0']
+    runCommand(arguments)
+  }
+
+}

--- a/gradle-android-command-plugin/src/main/groovy/com/novoda/gradle/command/DisableSystemAnimations.groovy
+++ b/gradle-android-command-plugin/src/main/groovy/com/novoda/gradle/command/DisableSystemAnimations.groovy
@@ -7,9 +7,9 @@ class DisableSystemAnimations extends AdbTask {
   @TaskAction
   void exec() {
     assertDeviceConnected()
-    disableAnimatorDuration()
-    disableTransitionAnimations()
     disableWindowAnimations()
+    disableTransitionAnimations()
+    disableAnimatorDuration()
   }
 
   private disableWindowAnimations() {

--- a/gradle-android-command-plugin/src/main/groovy/com/novoda/gradle/command/EnableSystemAnimations.groovy
+++ b/gradle-android-command-plugin/src/main/groovy/com/novoda/gradle/command/EnableSystemAnimations.groovy
@@ -1,0 +1,30 @@
+package com.novoda.gradle.command
+
+import org.gradle.api.tasks.TaskAction
+
+class EnableSystemAnimations extends AdbTask {
+
+  @TaskAction
+  void exec() {
+    assertDeviceConnected()
+    enableWindowAnimations()
+    enableTransitionAnimations()
+    enableAnimatorDuration()
+  }
+
+  private enableWindowAnimations() {
+    def arguments = ['shell', 'settings', 'put', 'global', 'window_animation_scale', '1']
+    runCommand(arguments)
+  }
+
+  private enableTransitionAnimations() {
+    def arguments = ['shell', 'settings', 'put', 'global', 'transition_animation_scale', '1']
+    runCommand(arguments)
+  }
+
+  private enableAnimatorDuration() {
+    def arguments = ['shell', 'settings', 'put', 'global', 'animator_duration_scale', '1']
+    runCommand(arguments)
+  }
+
+}


### PR DESCRIPTION
When running Espresso tests it is [recommended](https://google.github.io/android-testing-support-library/docs/espresso/setup/index.html#setup-your-test-environment) to turn off system animations. The new task `disableSystemAnimations` does this by executing the following adb commands:

```
adb shell settings put global window_animation_scale 0
adb shell settings put global transition_animation_scale 0
adb shell settings put global animator_duration_scale 0
```
