### PR TITLE
Bug: Enforce java 1.6 source compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.6.2
+- Fix source/target compatibility to Java 1.6
+
 # 1.6.1
 - Task to enable/disable system animations. [#96 by Said Tahsin Dane](https://github.com/novoda/gradle-android-command-plugin/pull/96)
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.novoda:gradle-android-command-plugin:1.6.1'
+        classpath 'com.novoda:gradle-android-command-plugin:1.6.2'
     }
 }
 

--- a/gradle-android-command-plugin/build.gradle
+++ b/gradle-android-command-plugin/build.gradle
@@ -18,7 +18,7 @@ dependencies {
 }
 
 group = 'com.novoda'
-version = '1.6.1'
+version = '1.6.2'
 
 publish {
     userOrg = 'novoda'

--- a/gradle-android-command-plugin/build.gradle
+++ b/gradle-android-command-plugin/build.gradle
@@ -10,6 +10,9 @@ buildscript {
 apply plugin: 'groovy'
 apply plugin: 'com.novoda.bintray-release'
 
+sourceCompatibility = JavaVersion.VERSION_1_6
+targetCompatibility = JavaVersion.VERSION_1_6
+
 dependencies {
     compile gradleApi()
 }
@@ -17,16 +20,10 @@ dependencies {
 group = 'com.novoda'
 version = '1.6.1'
 
-ext {
-    sourceCompatibility = 1.6
-    targetCompatibility = 1.6
-    artifactId = 'gradle-android-command-plugin'
-}
-
 publish {
     userOrg = 'novoda'
     groupId = 'com.novoda'
-    artifactId = project.ext.artifactId
+    artifactId = 'gradle-android-command-plugin'
     version = project.version
     description = 'Useful tasks for gradle android builds'
     website = 'https://github.com/novoda/gradle-android-command-plugin'


### PR DESCRIPTION
It seems like the command plugin wasn't defining the right source/target compatibility allowing to build an artifact not playing well with Android.
We decided to amend the plugin `build.gradle` to fix the issue, removing the misplaced properties from the project extension.