### PR TITLE
Cleanup finding Android Home folder.

### DIFF
--- a/plugin/src/main/groovy/com/novoda/gradle/command/AndroidCommandPlugin.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/AndroidCommandPlugin.groovy
@@ -13,10 +13,7 @@ public class AndroidCommandPlugin implements Plugin<Project> {
             throw new StopExecutionException("The 'android' plugin is required.")
         }
 
-        def androidExtension = project.android
-        String androidHome = getAndroidHome(androidExtension)
-
-        def extension = androidExtension.extensions.create("command", AndroidCommandPluginExtension, project, androidHome)
+        def extension = project.android.extensions.create("command", AndroidCommandPluginExtension, project)
         extension.task 'installDevice', 'installs the APK on the specified device', Install, ['assemble']
         extension.task 'run', 'installs and runs a APK on the specified device', Run, ['installDevice']
         extension.task 'start', 'runs an already installed APK on the specified device', Run
@@ -40,15 +37,4 @@ public class AndroidCommandPlugin implements Plugin<Project> {
         task.description = description
     }
 
-    private static String getAndroidHome(androidExtension) {
-        def androidHome
-        if (androidExtension.hasProperty('sdkHandler')) {
-            androidHome = "${androidExtension.sdkHandler.sdkFolder}"
-        } else if (androidExtension.hasProperty('sdkDirectory')) {
-            androidHome = "${androidExtension.sdkDirectory}"
-        } else {
-            throw new IllegalStateException('The android plugin is not exposing the SDK folder in an expected way.')
-        }
-        androidHome
-    }
 }

--- a/plugin/src/test/groovy/com/novoda/gradle/command/AndroidCommandPluginExtensionTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/gradle/command/AndroidCommandPluginExtensionTest.groovy
@@ -2,17 +2,13 @@ package com.novoda.gradle.command
 import org.gradle.testfixtures.ProjectBuilder
 
 class AndroidCommandPluginExtensionTest extends GroovyTestCase {
+
     private static final String SDK_PATH = '/some/path'
 
     void testDefaultAdbPath() {
         def extension = createExtension()
         assert extension.getAdb() != null
         assert extension.getAdb().contains('adb')
-    }
-
-    void testDefaultAndroidHomePath() {
-        def extension = createExtension()
-        assert extension.androidHome == SDK_PATH
     }
 
     void testDefaultEvents() {
@@ -31,8 +27,9 @@ class AndroidCommandPluginExtensionTest extends GroovyTestCase {
     }
 
     private static AndroidCommandPluginExtension createExtension() {
-        def projectDir = new File('..')
-        def project = ProjectBuilder.builder().withProjectDir(projectDir).build()
+        def project = ProjectBuilder.builder()
+                .withProjectDir(new File('..'))
+                .build()
         def extension = new AndroidCommandPluginExtension(project, SDK_PATH)
         extension
     }

--- a/sample/app/build.gradle
+++ b/sample/app/build.gradle
@@ -76,7 +76,6 @@ android {
         categories = ['android.intent.category.ONLY_ME']
         sortBySubtasks false
 
-
         task('runAmazon', com.novoda.gradle.command.Run) {
             deviceId {
                 def kindle = devices().find { it.brand() == 'Amazon' }


### PR DESCRIPTION
- Actual static method (finding AndroidHome) is simplified by returning early
- The setup is moved to Extension class. It was already like this before. I don't think it makes sense to provide Android Home separately as a constructor argument while we are already passing the `project`
- `defaultDeviceId` is renamed to `firstDeviceId` because it really returns the first device id.

- Test that tests `androidHome` properly set is removed. It is a private final field now. The test was only testing if the given argument is being set.