### PR TITLE
Use `adb` instead of `getAdb()` where possible

### DIFF
--- a/plugin/src/main/groovy/com/novoda/gradle/command/ActivityStack.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/ActivityStack.groovy
@@ -13,7 +13,7 @@ class ActivityStack extends AdbTask {
 
     def getActivityRecords() {
         def commandLine = ['shell', 'dumpsys', 'activity', '|', 'grep', '-i', 'run']
-        AdbCommand command = [adb: pluginEx.getAdb(), deviceId: getDeviceId(), parameters: commandLine]
+        AdbCommand command = [adb: pluginEx.adb, deviceId: getDeviceId(), parameters: commandLine]
         logger.info "running command: $command"
         def output = command.execute().text
 

--- a/plugin/src/main/groovy/com/novoda/gradle/command/AdbTask.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/AdbTask.groovy
@@ -54,7 +54,7 @@ public class AdbTask extends org.gradle.api.DefaultTask {
     }
 
     protected void runCommand(def parameters) {
-        AdbCommand command = [adb: pluginEx.getAdb(), deviceId: getDeviceId(), parameters: parameters]
+        AdbCommand command = [adb: pluginEx.adb, deviceId: getDeviceId(), parameters: parameters]
         logger.info "running command: $command"
         handleCommandOutput(command.execute().text)
     }

--- a/plugin/src/main/groovy/com/novoda/gradle/command/Files.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/Files.groovy
@@ -29,14 +29,14 @@ class Files extends AdbTask {
     }
 
     private String adb(String... params) {
-        AdbCommand adbCommand = [adb: pluginEx.getAdb(), deviceId: getDeviceId(), parameters: Arrays.asList(params) ]
+        AdbCommand adbCommand = [adb: pluginEx.adb, deviceId: getDeviceId(), parameters: Arrays.asList(params) ]
         adbCommand.execute().text
     }
 
     private String shell(... values) {
         def parameters = ['shell']
         parameters.addAll(values)
-        AdbCommand adbCommand = [adb: pluginEx.getAdb(), deviceId: getDeviceId(), parameters: parameters]
+        AdbCommand adbCommand = [adb: pluginEx.adb, deviceId: getDeviceId(), parameters: parameters]
         adbCommand.execute().text
     }
 

--- a/plugin/src/test/groovy/com/novoda/gradle/command/AndroidCommandPluginExtensionTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/gradle/command/AndroidCommandPluginExtensionTest.groovy
@@ -6,8 +6,8 @@ class AndroidCommandPluginExtensionTest extends GroovyTestCase {
 
     void testDefaultAdbPath() {
         def extension = createExtension()
-        assert extension.getAdb() != null
-        assert extension.getAdb().contains('adb')
+        assert extension.adb != null
+        assert extension.adb.contains('adb')
     }
 
     void testDefaultAndroidHomePath() {
@@ -17,17 +17,17 @@ class AndroidCommandPluginExtensionTest extends GroovyTestCase {
 
     void testDefaultEvents() {
         def extension = createExtension()
-        assert extension.getEvents() == AndroidCommandPluginExtension.EVENTS_DEFAULT
+        assert extension.events == AndroidCommandPluginExtension.EVENTS_DEFAULT
     }
 
     void testDefaultSeed() {
         def extension = createExtension()
-        assert extension.getSeed() == null
+        assert extension.seed == null
     }
 
     void testDefaultCategories() {
         def extension = createExtension()
-        assert extension.getCategories() == null
+        assert extension.categories == null
     }
 
     private static AndroidCommandPluginExtension createExtension() {


### PR DESCRIPTION
I thought we can have more `groovy` style access by using the field name where it uses the getter already.