### PR TITLE
Installation errors should break the build

### DIFF
--- a/plugin/src/main/groovy/com/novoda/gradle/command/Device.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/Device.groovy
@@ -70,6 +70,6 @@ class Device {
     }
 
     String toString() {
-        getClass().name + [id: id, sdk: sdkVersion(), version: androidVersion(), brand: brand(), manufacturer: manufacturer(), model: model(), country: country(), language: language(), timezone: timezone()]
+        getClass().simpleName + [id: id, sdk: sdkVersion(), version: androidVersion(), brand: brand(), manufacturer: manufacturer(), model: model(), country: country(), language: language(), timezone: timezone()]
     }
 }

--- a/plugin/src/main/groovy/com/novoda/gradle/command/Install.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/Install.groovy
@@ -23,4 +23,12 @@ class Install extends AdbTask {
         customFlags ?: ''
     }
 
+    @Override
+    protected handleCommandOutput(def text) {
+        super.handleCommandOutput(text)
+        def matcher = text =~ /Failure \[(.*?)\]/
+        if (matcher) {
+            throw new GroovyRuntimeException("Installation failed with error: ${matcher[0][1]}")
+        }
+    }
 }


### PR DESCRIPTION
### The Problem 
The problem was that the build was marked as successful even when the installation failed. 
This was bad for `installDevice` task. But it was even worse for `run` because it runs the old version assuming that the installation was successful.

### Solution 

Our plugin does not really handles errors. Also the `adb` almost always exits with success (code 0) and never writes into error stream.
We should investigate and maybe even report back to Google places where we can make use of error codes. 

But in this specific case (APK installation), it is feasible to look at the output. 

Now, I am searching for `Failure` in the text and break the build with the original failure error code. It looks like this: 

![image](https://cloud.githubusercontent.com/assets/763339/21650228/8ed2a440-d2a4-11e6-9271-c11a416bd1a3.png)

Fixes #46