### PR TITLE
Refactor monkey task configuration

### DIFF
--- a/plugin/src/main/groovy/com/novoda/gradle/command/AdbTask.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/AdbTask.groovy
@@ -5,7 +5,7 @@ import groovy.transform.Memoized
 
 public class AdbTask extends org.gradle.api.DefaultTask {
 
-    protected pluginEx = project.android.extensions.findByType(AndroidCommandPluginExtension)
+    final def pluginEx = project.android.extensions.findByType(AndroidCommandPluginExtension)
 
     // set automatically by VariantConfigurator
     def apkPath

--- a/plugin/src/main/groovy/com/novoda/gradle/command/AdbTask.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/AdbTask.groovy
@@ -5,7 +5,7 @@ import groovy.transform.Memoized
 
 public class AdbTask extends org.gradle.api.DefaultTask {
 
-    final def pluginEx = project.android.extensions.findByType(AndroidCommandPluginExtension)
+    final pluginEx = project.android.extensions.findByType(AndroidCommandPluginExtension)
 
     // set automatically by VariantConfigurator
     def apkPath

--- a/plugin/src/main/groovy/com/novoda/gradle/command/AndroidCommandPluginExtension.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/AndroidCommandPluginExtension.groovy
@@ -6,8 +6,6 @@ import org.gradle.api.Project
 
 public class AndroidCommandPluginExtension {
 
-    static final int EVENTS_DEFAULT = 10000
-
     def adb
     def aapt
     def deviceId

--- a/plugin/src/main/groovy/com/novoda/gradle/command/AndroidCommandPluginExtension.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/AndroidCommandPluginExtension.groovy
@@ -1,6 +1,7 @@
 package com.novoda.gradle.command
 
 import groovy.transform.Memoized
+import org.gradle.api.Action
 import org.gradle.api.Project
 
 public class AndroidCommandPluginExtension {
@@ -10,13 +11,11 @@ public class AndroidCommandPluginExtension {
     def adb
     def aapt
     def deviceId
-    def events
-    def seed
-    def categories
     def sortBySubtasks
 
     private final Project project
     private final String androidHome
+    private final Monkey.Spec monkey
 
     AndroidCommandPluginExtension(Project project) {
         this(project, findAndroidHomeFrom(project.android))
@@ -25,6 +24,7 @@ public class AndroidCommandPluginExtension {
     AndroidCommandPluginExtension(Project project, String androidHome) {
         this.project = project
         this.androidHome = androidHome
+        this.monkey = new Monkey.Spec()
     }
 
     def task(String name, Class<? extends AdbTask> type, Closure configuration) {
@@ -77,18 +77,12 @@ public class AndroidCommandPluginExtension {
         deviceId ?: firstDeviceId()
     }
 
-    // prefer system property over direct setting to enable commandline arguments
-    def getEvents() {
-        System.properties['events'] ?: events ?: EVENTS_DEFAULT
+    public void monkey(Action<Monkey.Spec> action) {
+        action.execute(monkey);
     }
 
-    // prefer system property over direct setting to enable commandline arguments
-    def getCategories() {
-        System.properties['categories'] ?: categories
-    }
-
-    def getSeed() {
-        System.properties['seed'] ?: seed
+    public Monkey.Spec getMonkey() {
+        monkey
     }
 
     def devices() {

--- a/plugin/src/main/groovy/com/novoda/gradle/command/AndroidCommandPluginExtension.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/AndroidCommandPluginExtension.groovy
@@ -75,11 +75,11 @@ public class AndroidCommandPluginExtension {
         deviceId ?: firstDeviceId()
     }
 
-    public void monkey(Action<MonkeySpec> action) {
-        action.execute(monkey);
+    void monkey(Action<MonkeySpec> action) {
+        action.execute(monkey)
     }
 
-    public MonkeySpec getMonkey() {
+    MonkeySpec getMonkey() {
         monkey
     }
 

--- a/plugin/src/main/groovy/com/novoda/gradle/command/AndroidCommandPluginExtension.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/AndroidCommandPluginExtension.groovy
@@ -15,7 +15,7 @@ public class AndroidCommandPluginExtension {
 
     private final Project project
     private final String androidHome
-    private final Monkey.Spec monkey
+    private final MonkeySpec monkey
 
     AndroidCommandPluginExtension(Project project) {
         this(project, findAndroidHomeFrom(project.android))
@@ -24,7 +24,7 @@ public class AndroidCommandPluginExtension {
     AndroidCommandPluginExtension(Project project, String androidHome) {
         this.project = project
         this.androidHome = androidHome
-        this.monkey = new Monkey.Spec()
+        this.monkey = new MonkeySpec()
     }
 
     def task(String name, Class<? extends AdbTask> type, Closure configuration) {
@@ -77,11 +77,11 @@ public class AndroidCommandPluginExtension {
         deviceId ?: firstDeviceId()
     }
 
-    public void monkey(Action<Monkey.Spec> action) {
+    public void monkey(Action<MonkeySpec> action) {
         action.execute(monkey);
     }
 
-    public Monkey.Spec getMonkey() {
+    public MonkeySpec getMonkey() {
         monkey
     }
 

--- a/plugin/src/main/groovy/com/novoda/gradle/command/Monkey.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/Monkey.groovy
@@ -13,9 +13,7 @@ class Monkey extends AdbTask {
 
     @TaskAction
     void exec() {
-        Spec monkey = pluginEx.monkey
-
-        logger.info monkey.categories.toString()
+        MonkeySpec monkey = pluginEx.monkey
 
         def arguments = ['shell', 'monkey']
         arguments += ['-p', packageName]
@@ -25,41 +23,5 @@ class Monkey extends AdbTask {
             arguments += ['-s', monkey.seed]
         }
         assertDeviceAndRunCommand(arguments)
-    }
-
-    static class Spec {
-
-        private static final int EVENTS_DEFAULT = 10000
-
-        def events
-        def seed
-        def categories = []
-
-        void events(events) {
-            this.events = events
-        }
-
-        void seed(seed) {
-            this.seed = seed
-        }
-
-        void categories(... categories) {
-            this.categories.addAll(categories)
-        }
-
-        // prefer system property over direct setting to enable commandline arguments
-        def getEvents() {
-            System.properties['events'] ?: events ?: EVENTS_DEFAULT
-        }
-
-        // prefer system property over direct setting to enable commandline arguments
-        def getCategories() {
-            def systemCategories = System.properties['categories']
-            systemCategories ? [systemCategories] : categories
-        }
-
-        def getSeed() {
-            System.properties['seed'] ?: seed
-        }
     }
 }

--- a/plugin/src/main/groovy/com/novoda/gradle/command/MonkeySpec.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/MonkeySpec.groovy
@@ -1,0 +1,37 @@
+package com.novoda.gradle.command;
+
+final class MonkeySpec {
+
+    private static final int EVENTS_DEFAULT = 10000
+
+    def events
+    def seed
+    def categories = []
+
+    void events(events) {
+        this.events = events
+    }
+
+    void seed(seed) {
+        this.seed = seed
+    }
+
+    void categories(... categories) {
+        this.categories.addAll(categories)
+    }
+
+    // prefer system property over direct setting to enable commandline arguments
+    def getEvents() {
+        System.properties['events'] ?: events ?: EVENTS_DEFAULT
+    }
+
+    // prefer system property over direct setting to enable commandline arguments
+    def getCategories() {
+        def systemCategories = System.properties['categories']
+        systemCategories ? [systemCategories] : categories
+    }
+
+    def getSeed() {
+        System.properties['seed'] ?: seed
+    }
+}

--- a/plugin/src/main/groovy/com/novoda/gradle/command/MonkeySpec.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/MonkeySpec.groovy
@@ -4,9 +4,9 @@ final class MonkeySpec {
 
     static final int EVENTS_DEFAULT = 10000
 
-    def events
-    def seed
-    def categories = []
+    Integer events
+    Integer seed
+    List<String> categories = []
 
     void events(events) {
         this.events = events

--- a/plugin/src/main/groovy/com/novoda/gradle/command/MonkeySpec.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/MonkeySpec.groovy
@@ -2,7 +2,7 @@ package com.novoda.gradle.command;
 
 final class MonkeySpec {
 
-    private static final int EVENTS_DEFAULT = 10000
+    static final int EVENTS_DEFAULT = 10000
 
     def events
     def seed

--- a/plugin/src/test/groovy/com/novoda/gradle/command/AndroidCommandPluginExtensionTest.groovy
+++ b/plugin/src/test/groovy/com/novoda/gradle/command/AndroidCommandPluginExtensionTest.groovy
@@ -11,19 +11,11 @@ class AndroidCommandPluginExtensionTest extends GroovyTestCase {
         assert extension.adb.contains('adb')
     }
 
-    void testDefaultEvents() {
+    void testDefaultMonkey() {
         def extension = createExtension()
-        assert extension.events == AndroidCommandPluginExtension.EVENTS_DEFAULT
-    }
-
-    void testDefaultSeed() {
-        def extension = createExtension()
-        assert extension.seed == null
-    }
-
-    void testDefaultCategories() {
-        def extension = createExtension()
-        assert extension.categories == null
+        assert extension.monkey.events == MonkeySpec.EVENTS_DEFAULT
+        assert extension.monkey.seed == null
+        assert extension.monkey.categories == []
     }
 
     private static AndroidCommandPluginExtension createExtension() {

--- a/sample/app/build.gradle
+++ b/sample/app/build.gradle
@@ -72,8 +72,10 @@ android {
             minSdkDevice.id
         }
 
-        events 1000
-        categories = ['android.intent.category.ONLY_ME']
+        monkey {
+            events 1000
+            categories 'android.intent.category.ONLY_ME', 'android.intent.category.ONLY_YOU'
+        }
         sortBySubtasks false
 
         task('runAmazon', com.novoda.gradle.command.Run) {

--- a/sample/app/build.gradle
+++ b/sample/app/build.gradle
@@ -74,7 +74,7 @@ android {
 
         monkey {
             events 1000
-            categories 'android.intent.category.ONLY_ME', 'android.intent.category.ONLY_YOU'
+            categories 'android.intent.category.ONLY_ME', 'android.intent.category.MONKEY'
         }
         sortBySubtasks false
 


### PR DESCRIPTION
This PR fixes #105 

There are still things to improve how we setup our tasks but this PR is the first step to have more gradle DSL like setup for the config of the tasks. 

- Fields related to monkey are removed both from the extension and from the `Monkey` task class. 
  - They are now encapsulated in `MonkeySpec` class. 
- `MonkeySpec` is always initialized but its internals are set using the `Action` class of gradle. 
  - It runs a given closure against the `monkey` field in the extension. 
  - the sample is updated to have the new way of configuring monkey. 

⚠️ This is a breaking change of the public API. The users will need to wrap the monkey configuration into another closure named `monkey`. (Can be seen in the sample)

Depending on the decision here, we may have a follow-up PR to support to old configuration still. 
Having the change documented well could also be enough. If we break the API, the upgraded version of the plugin will break the build which then can be easily fixed. 

#### Bonus

This also works and it is great for simple configurations. 

```groovy
command {
  monkey.events 1000
}
```

as opposed to this from the sample

```groovy
command {
  monkey {
    events 1000
  }
}
```