### PR TITLE
Decouple extension from tasks

### DIFF
--- a/plugin/src/main/groovy/com/novoda/gradle/command/ActivityStack.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/ActivityStack.groovy
@@ -13,9 +13,7 @@ class ActivityStack extends AdbTask {
 
     def getActivityRecords() {
         def commandLine = ['shell', 'dumpsys', 'activity', '|', 'grep', '-i', 'run']
-
-        adbCommand.deviceId = getDeviceId()
-        adbCommand.parameters = commandLine
+        AdbCommand command = [adb: adb, deviceId: deviceId, parameters: commandLine]
         logger.info "running command: $command"
         def output = command.execute().text
 

--- a/plugin/src/main/groovy/com/novoda/gradle/command/ActivityStack.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/ActivityStack.groovy
@@ -13,7 +13,9 @@ class ActivityStack extends AdbTask {
 
     def getActivityRecords() {
         def commandLine = ['shell', 'dumpsys', 'activity', '|', 'grep', '-i', 'run']
-        AdbCommand command = [adb: pluginEx.adb, deviceId: getDeviceId(), parameters: commandLine]
+
+        adbCommand.deviceId = getDeviceId()
+        adbCommand.parameters = commandLine
         logger.info "running command: $command"
         def output = command.execute().text
 

--- a/plugin/src/main/groovy/com/novoda/gradle/command/ActivityStack.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/ActivityStack.groovy
@@ -13,8 +13,8 @@ class ActivityStack extends AdbTask {
 
     def getActivityRecords() {
         def commandLine = ['shell', 'dumpsys', 'activity', '|', 'grep', '-i', 'run']
-        def adb = this.adb ?: resolveFromExtension("adb")
-        def deviceId = this.deviceId ?: resolveFromExtension("deviceId")
+        def adb = this.adb ?: resolveFromExtension('adb')
+        def deviceId = this.deviceId ?: resolveFromExtension('deviceId')
         AdbCommand command = [adb: adb, deviceId: deviceId, parameters: commandLine]
         logger.info "running command: $command"
         def output = command.execute().text

--- a/plugin/src/main/groovy/com/novoda/gradle/command/ActivityStack.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/ActivityStack.groovy
@@ -13,6 +13,8 @@ class ActivityStack extends AdbTask {
 
     def getActivityRecords() {
         def commandLine = ['shell', 'dumpsys', 'activity', '|', 'grep', '-i', 'run']
+        def adb = this.adb ?: resolveFromExtension("adb")
+        def deviceId = this.deviceId ?: resolveFromExtension("deviceId")
         AdbCommand command = [adb: adb, deviceId: deviceId, parameters: commandLine]
         logger.info "running command: $command"
         def output = command.execute().text

--- a/plugin/src/main/groovy/com/novoda/gradle/command/AdbTask.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/AdbTask.groovy
@@ -39,8 +39,8 @@ public class AdbTask extends org.gradle.api.DefaultTask {
     }
 
     protected void assertDeviceConnected() {
-        def adb = getAdb() ?: resolveFromExtension("adb")
-        def deviceId = getDeviceId() ?: resolveFromExtension("deviceId")
+        def adb = getAdb() ?: resolveFromExtension('adb')
+        def deviceId = getDeviceId() ?: resolveFromExtension('deviceId')
         AdbCommand command = [adb: adb, deviceId: deviceId, parameters: 'get-state']
         if (command.execute().text.trim() != 'device')
             throw new IllegalStateException("No device with ID $deviceId found.")
@@ -54,8 +54,8 @@ public class AdbTask extends org.gradle.api.DefaultTask {
     }
 
     protected void runCommand(def parameters) {
-        def adb = getAdb() ?: resolveFromExtension("adb")
-        def deviceId = getDeviceId() ?: resolveFromExtension("deviceId")
+        def adb = getAdb() ?: resolveFromExtension('adb')
+        def deviceId = getDeviceId() ?: resolveFromExtension('deviceId')
         AdbCommand command = [adb: adb, deviceId: deviceId, parameters: parameters]
         logger.info "running command: $command"
         handleCommandOutput(command.execute().text)
@@ -69,7 +69,7 @@ public class AdbTask extends org.gradle.api.DefaultTask {
         if (!apkPath) {
             throw new IllegalStateException("No APK found for the '$name' task")
         }
-        def aapt = getAapt() ?: resolveFromExtension("aapt")
+        def aapt = getAapt() ?: resolveFromExtension('aapt')
         String output = [aapt, 'dump', 'badging', apkPath].execute().text.readLines().find {
             it.startsWith("$propertyKey:")
         }

--- a/plugin/src/main/groovy/com/novoda/gradle/command/AdbTask.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/AdbTask.groovy
@@ -7,6 +7,8 @@ public class AdbTask extends org.gradle.api.DefaultTask {
 
     final pluginEx = project.android.extensions.findByType(AndroidCommandPluginExtension)
 
+    AdbCommand adbCommand;
+
     // set automatically by VariantConfigurator
     def apkPath
 
@@ -54,9 +56,10 @@ public class AdbTask extends org.gradle.api.DefaultTask {
     }
 
     protected void runCommand(def parameters) {
-        AdbCommand command = [adb: pluginEx.adb, deviceId: getDeviceId(), parameters: parameters]
-        logger.info "running command: $command"
-        handleCommandOutput(command.execute().text)
+        adbCommand.deviceId = getDeviceId()
+        adbCommand.parameters = parameters
+        logger.info "running command: $adbCommand"
+        handleCommandOutput(adbCommand.execute().text)
     }
 
     protected handleCommandOutput(def text)  {

--- a/plugin/src/main/groovy/com/novoda/gradle/command/AdbTask.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/AdbTask.groovy
@@ -79,7 +79,7 @@ public class AdbTask extends org.gradle.api.DefaultTask {
     // TODO: Remove this once we have support for nice DSL support for tasks
     @Deprecated
     final resolveFromExtension(property) {
-        logger.error """\
+        logger.warn """\
                         $property not specified for the task $name.
                         Automatically resolving $property via the plugin.
                         This support will be removed with the next version of the plugin.

--- a/plugin/src/main/groovy/com/novoda/gradle/command/AdbTask.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/AdbTask.groovy
@@ -44,7 +44,7 @@ public class AdbTask extends org.gradle.api.DefaultTask {
         AdbCommand command = [adb: adb, deviceId: deviceId, parameters: 'get-state']
         if (command.execute().text != 'device')
             throw new IllegalStateException("No device with ID $deviceId found.")
-        printDeviceInfo(device)
+        printDeviceInfo(new Device(adb, deviceId))
     }
 
     private printDeviceInfo(device) {

--- a/plugin/src/main/groovy/com/novoda/gradle/command/AdbTask.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/AdbTask.groovy
@@ -42,7 +42,7 @@ public class AdbTask extends org.gradle.api.DefaultTask {
         def adb = getAdb() ?: resolveFromExtension("adb")
         def deviceId = getDeviceId() ?: resolveFromExtension("deviceId")
         AdbCommand command = [adb: adb, deviceId: deviceId, parameters: 'get-state']
-        if (command.execute().text != 'device')
+        if (command.execute().text.trim() != 'device')
             throw new IllegalStateException("No device with ID $deviceId found.")
         printDeviceInfo(new Device(adb, deviceId))
     }

--- a/plugin/src/main/groovy/com/novoda/gradle/command/AdbTask.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/AdbTask.groovy
@@ -7,15 +7,15 @@ public class AdbTask extends org.gradle.api.DefaultTask {
 
     final pluginEx = project.android.extensions.findByType(AndroidCommandPluginExtension)
 
-    AdbCommand adbCommand;
+    def adb
+    def aapt
+    def deviceId
 
     // set automatically by VariantConfigurator
     def apkPath
 
     // set automatically by VariantConfigurator
     def variationName
-
-    def deviceId
 
     @Memoized
     def getDeviceId() {
@@ -56,10 +56,9 @@ public class AdbTask extends org.gradle.api.DefaultTask {
     }
 
     protected void runCommand(def parameters) {
-        adbCommand.deviceId = getDeviceId()
-        adbCommand.parameters = parameters
-        logger.info "running command: $adbCommand"
-        handleCommandOutput(adbCommand.execute().text)
+        AdbCommand command = [adb: getAdb(), deviceId: getDeviceId(), parameters: parameters]
+        logger.info "running command: $command"
+        handleCommandOutput(command.execute().text)
     }
 
     protected handleCommandOutput(def text)  {
@@ -70,7 +69,7 @@ public class AdbTask extends org.gradle.api.DefaultTask {
         if (!apkPath) {
             throw new IllegalStateException("No APK found for the '$name' task")
         }
-        String output = [pluginEx.aapt, 'dump', 'badging', apkPath].execute().text.readLines().find {
+        String output = [getAapt(), 'dump', 'badging', apkPath].execute().text.readLines().find {
             it.startsWith("$propertyKey:")
         }
         output

--- a/plugin/src/main/groovy/com/novoda/gradle/command/AdbTask.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/AdbTask.groovy
@@ -21,7 +21,7 @@ public class AdbTask extends org.gradle.api.DefaultTask {
     def getDeviceId() {
         if (deviceId instanceof Closure)
             deviceId = deviceId.call()
-        deviceId ?: pluginEx.deviceId
+        deviceId
     }
 
     def getPackageName() {

--- a/plugin/src/main/groovy/com/novoda/gradle/command/AdbTask.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/AdbTask.groovy
@@ -5,8 +5,6 @@ import groovy.transform.Memoized
 
 public class AdbTask extends org.gradle.api.DefaultTask {
 
-    final pluginEx = project.android.extensions.findByType(AndroidCommandPluginExtension)
-
     def adb
     def aapt
     def deviceId
@@ -42,10 +40,9 @@ public class AdbTask extends org.gradle.api.DefaultTask {
     }
 
     protected void assertDeviceConnected() {
-        def id = getDeviceId()
-        Device device = pluginEx.devices().find { device -> device.id == id }
-        if (!device)
-            throw new IllegalStateException("No device with ID $id found.")
+        AdbCommand command = [adb: getAdb(), deviceId: getDeviceId(), parameters: 'get-state']
+        if (command.execute().text != 'device')
+            throw new IllegalStateException("No device with ID ${getDeviceId()} found.")
         printDeviceInfo(device)
     }
 

--- a/plugin/src/main/groovy/com/novoda/gradle/command/AndroidCommandPlugin.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/AndroidCommandPlugin.groovy
@@ -21,11 +21,9 @@ public class AndroidCommandPlugin implements Plugin<Project> {
         extension.task 'clearPrefs', 'clears the shared preferences on the specified device', ClearPreferences
         extension.task 'uninstallDevice', 'uninstalls the APK from the specific device', Uninstall
 
-        project.afterEvaluate {
-            def monkeyTasks = extension.task 'monkey', 'calls the monkey command on the specified device', Monkey, ['installDevice']
-            monkeyTasks.all { task ->
-                task.monkey = extension.monkey
-            }
+        def monkeyTasks = extension.task 'monkey', 'calls the monkey command on the specified device', Monkey, ['installDevice']
+        monkeyTasks.all {
+            conventionMapping.monkey = { extension.monkey }
         }
 
         defaultTask (project, 'enableSystemAnimations', 'enables system animations on the connected device', SystemAnimations) {

--- a/plugin/src/main/groovy/com/novoda/gradle/command/AndroidCommandPlugin.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/AndroidCommandPlugin.groovy
@@ -18,9 +18,15 @@ public class AndroidCommandPlugin implements Plugin<Project> {
         extension.task 'run', 'installs and runs a APK on the specified device', Run, ['installDevice']
         extension.task 'start', 'runs an already installed APK on the specified device', Run
         extension.task 'stop', 'forcibly stops the app on the specified device', Stop
-        extension.task 'monkey', 'calls the monkey command on the specified device', Monkey, ['installDevice']
         extension.task 'clearPrefs', 'clears the shared preferences on the specified device', ClearPreferences
         extension.task 'uninstallDevice', 'uninstalls the APK from the specific device', Uninstall
+
+        project.afterEvaluate {
+            def monkeyTasks = extension.task 'monkey', 'calls the monkey command on the specified device', Monkey, ['installDevice']
+            monkeyTasks.all { task ->
+                task.monkey = extension.monkey
+            }
+        }
 
         defaultTask (project, 'enableSystemAnimations', 'enables system animations on the connected device', SystemAnimations) {
             enable = true

--- a/plugin/src/main/groovy/com/novoda/gradle/command/AndroidCommandPluginExtension.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/AndroidCommandPluginExtension.groovy
@@ -46,7 +46,8 @@ public class AndroidCommandPluginExtension {
     }
 
     def task(String name, String description, Class<? extends AdbTask> type, def dependencies) {
-        VariantConfigurator variantConfigurator = new VariantConfigurator(project, name, description, type, dependencies)
+        AdbCommand adbCommand = [adb: getAdb(), deviceId: getDeviceId()]
+        VariantConfigurator variantConfigurator = new VariantConfigurator(project, adbCommand, name, description, type, dependencies)
         project.android.applicationVariants.all {
             variantConfigurator.configure(it)
         }

--- a/plugin/src/main/groovy/com/novoda/gradle/command/AndroidCommandPluginExtension.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/AndroidCommandPluginExtension.groovy
@@ -46,8 +46,7 @@ public class AndroidCommandPluginExtension {
     }
 
     def task(String name, String description, Class<? extends AdbTask> type, def dependencies) {
-        AdbCommand adbCommand = [adb: getAdb(), deviceId: getDeviceId()]
-        VariantConfigurator variantConfigurator = new VariantConfigurator(project, adbCommand, name, description, type, dependencies)
+        VariantConfigurator variantConfigurator = new VariantConfigurator(this, project, name, description, type, dependencies)
         project.android.applicationVariants.all {
             variantConfigurator.configure(it)
         }

--- a/plugin/src/main/groovy/com/novoda/gradle/command/Files.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/Files.groovy
@@ -29,15 +29,14 @@ class Files extends AdbTask {
     }
 
     private String adb(String... params) {
-        adbCommand.deviceId = getDeviceId()
-        adbCommand.parameters = Arrays.asList(params)
+        AdbCommand adbCommand = [adb: adb, deviceId: deviceId, parameters: Arrays.asList(params) ]
         adbCommand.execute().text
     }
 
     private String shell(... values) {
-        adbCommand.deviceId = getDeviceId()
-        adbCommand.parameters = ['shell']
-        adbCommand.parameters.addAll(values)
+        def parameters = ['shell']
+        parameters.addAll(values)
+        AdbCommand adbCommand = [adb: adb, deviceId: deviceId, parameters: parameters]
         adbCommand.execute().text
     }
 

--- a/plugin/src/main/groovy/com/novoda/gradle/command/Files.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/Files.groovy
@@ -29,14 +29,15 @@ class Files extends AdbTask {
     }
 
     private String adb(String... params) {
-        AdbCommand adbCommand = [adb: pluginEx.adb, deviceId: getDeviceId(), parameters: Arrays.asList(params) ]
+        adbCommand.deviceId = getDeviceId()
+        adbCommand.parameters = Arrays.asList(params)
         adbCommand.execute().text
     }
 
     private String shell(... values) {
-        def parameters = ['shell']
-        parameters.addAll(values)
-        AdbCommand adbCommand = [adb: pluginEx.adb, deviceId: getDeviceId(), parameters: parameters]
+        adbCommand.deviceId = getDeviceId()
+        adbCommand.parameters = ['shell']
+        adbCommand.parameters.addAll(values)
         adbCommand.execute().text
     }
 

--- a/plugin/src/main/groovy/com/novoda/gradle/command/Files.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/Files.groovy
@@ -29,15 +29,14 @@ class Files extends AdbTask {
     }
 
     private String shell(... values) {
-        String[] parameters = ['shell']
-        parameters.addAll(values)
-        adb(parameters)
+        def params = ['shell'] + (values as List)
+        adb(*params)
     }
 
     private String adb(String... params) {
         def adb = getAdb() ?: resolveFromExtension('adb')
         def deviceId = getDeviceId() ?: resolveFromExtension('deviceId')
-        AdbCommand adbCommand = [adb: adb, deviceId: deviceId, parameters: Arrays.asList(params) ]
+        AdbCommand adbCommand = [adb: adb, deviceId: deviceId, parameters: params as List ]
         adbCommand.execute().text
     }
 

--- a/plugin/src/main/groovy/com/novoda/gradle/command/Files.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/Files.groovy
@@ -35,8 +35,8 @@ class Files extends AdbTask {
     }
 
     private String adb(String... params) {
-        def adb = getAdb() ?: resolveFromExtension("adb")
-        def deviceId = getDeviceId() ?: resolveFromExtension("deviceId")
+        def adb = getAdb() ?: resolveFromExtension('adb')
+        def deviceId = getDeviceId() ?: resolveFromExtension('deviceId')
         AdbCommand adbCommand = [adb: adb, deviceId: deviceId, parameters: Arrays.asList(params) ]
         adbCommand.execute().text
     }

--- a/plugin/src/main/groovy/com/novoda/gradle/command/Files.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/Files.groovy
@@ -41,7 +41,6 @@ class Files extends AdbTask {
         adbCommand.execute().text
     }
 
-
     @TaskAction
     void exec() {
         assertDeviceConnected()

--- a/plugin/src/main/groovy/com/novoda/gradle/command/Files.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/Files.groovy
@@ -28,17 +28,19 @@ class Files extends AdbTask {
         shell('ls -la', dir)
     }
 
+    private String shell(... values) {
+        String[] parameters = ['shell']
+        parameters.addAll(values)
+        adb(parameters)
+    }
+
     private String adb(String... params) {
+        def adb = getAdb() ?: resolveFromExtension("adb")
+        def deviceId = getDeviceId() ?: resolveFromExtension("deviceId")
         AdbCommand adbCommand = [adb: adb, deviceId: deviceId, parameters: Arrays.asList(params) ]
         adbCommand.execute().text
     }
 
-    private String shell(... values) {
-        def parameters = ['shell']
-        parameters.addAll(values)
-        AdbCommand adbCommand = [adb: adb, deviceId: deviceId, parameters: parameters]
-        adbCommand.execute().text
-    }
 
     @TaskAction
     void exec() {

--- a/plugin/src/main/groovy/com/novoda/gradle/command/Monkey.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/Monkey.groovy
@@ -4,7 +4,7 @@ import org.gradle.api.tasks.TaskAction
 
 class Monkey extends AdbTask {
 
-    MonkeySpec monkey;
+    MonkeySpec monkey
 
     protected handleCommandOutput(def text) {
         super.handleCommandOutput(text)
@@ -15,6 +15,7 @@ class Monkey extends AdbTask {
 
     @TaskAction
     void exec() {
+        def monkey = getMonkey()
         def arguments = ['shell', 'monkey']
         arguments += ['-p', packageName]
         arguments += monkey.categories.collect { ['-c', it] }.flatten()

--- a/plugin/src/main/groovy/com/novoda/gradle/command/Monkey.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/Monkey.groovy
@@ -4,6 +4,8 @@ import org.gradle.api.tasks.TaskAction
 
 class Monkey extends AdbTask {
 
+    MonkeySpec monkey;
+
     protected handleCommandOutput(def text) {
         super.handleCommandOutput(text)
         if (text.toLowerCase().contains("monkey aborted")) {
@@ -13,8 +15,6 @@ class Monkey extends AdbTask {
 
     @TaskAction
     void exec() {
-        MonkeySpec monkey = pluginEx.monkey
-
         def arguments = ['shell', 'monkey']
         arguments += ['-p', packageName]
         arguments += monkey.categories.collect { ['-c', it] }.flatten()

--- a/plugin/src/main/groovy/com/novoda/gradle/command/Run.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/Run.groovy
@@ -22,6 +22,7 @@ class Run extends AdbTask {
             // https://code.google.com/p/android/issues/detail?id=157150
             logger.info 'no launchable-activity found, falling back to parsing the manifest'
 
+            def aapt = this.aapt ?: resolveFromExtension("aapt")
             output = [aapt, 'dump', 'xmltree', apkPath, 'AndroidManifest.xml'].execute().text
 
             def it = output.readLines().iterator()

--- a/plugin/src/main/groovy/com/novoda/gradle/command/Run.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/Run.groovy
@@ -22,7 +22,7 @@ class Run extends AdbTask {
             // https://code.google.com/p/android/issues/detail?id=157150
             logger.info 'no launchable-activity found, falling back to parsing the manifest'
 
-            def aapt = this.aapt ?: resolveFromExtension("aapt")
+            def aapt = this.aapt ?: resolveFromExtension('aapt')
             output = [aapt, 'dump', 'xmltree', apkPath, 'AndroidManifest.xml'].execute().text
 
             def it = output.readLines().iterator()

--- a/plugin/src/main/groovy/com/novoda/gradle/command/Run.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/Run.groovy
@@ -22,7 +22,7 @@ class Run extends AdbTask {
             // https://code.google.com/p/android/issues/detail?id=157150
             logger.info 'no launchable-activity found, falling back to parsing the manifest'
 
-            output = [pluginEx.aapt, 'dump', 'xmltree', apkPath, 'AndroidManifest.xml'].execute().text
+            output = [aapt, 'dump', 'xmltree', apkPath, 'AndroidManifest.xml'].execute().text
 
             def it = output.readLines().iterator()
             def nextLine = null

--- a/plugin/src/main/groovy/com/novoda/gradle/command/VariantConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/VariantConfigurator.groovy
@@ -36,7 +36,7 @@ class VariantConfigurator {
         task.conventionMapping.aapt = { extension.aapt }
         task.conventionMapping.deviceId = { extension.deviceId }
 
-        if (task.pluginEx && task.pluginEx.sortBySubtasks) {
+        if (extension.sortBySubtasks) {
             task.group = AndroidCommandPlugin.TASK_GROUP + " " + taskName;
         } else {
             task.group = AndroidCommandPlugin.TASK_GROUP + " for variant " + variationName;

--- a/plugin/src/main/groovy/com/novoda/gradle/command/VariantConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/VariantConfigurator.groovy
@@ -8,14 +8,19 @@ class VariantConfigurator {
     private final String description
     private final Class<? extends AdbTask> taskType
     private final def dependencies
+    private final AdbCommand adbCommand
 
-    VariantConfigurator(Project project, String taskName, String description, Class<? extends AdbTask> taskType,
+    VariantConfigurator(Project project,
+                        AdbCommand adbCommand,
+                        String taskName,
+                        String description,
+                        Class<? extends AdbTask> taskType,
                         def dependencies) {
-
+        this.project = project
+        this.adbCommand = adbCommand
         this.taskType = taskType
         this.taskName = taskName
         this.description = description
-        this.project = project
         this.dependencies = dependencies
     }
 
@@ -26,6 +31,8 @@ class VariantConfigurator {
         def variationName = projectFlavorName + buildTypeName
 
         AdbTask task = project.tasks.create(taskName + variationName, taskType)
+
+        task.adbCommand = adbCommand
 
         if (task.pluginEx && task.pluginEx.sortBySubtasks) {
             task.group = AndroidCommandPlugin.TASK_GROUP + " " + taskName;

--- a/plugin/src/main/groovy/com/novoda/gradle/command/VariantConfigurator.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/VariantConfigurator.groovy
@@ -3,21 +3,21 @@ package com.novoda.gradle.command
 import org.gradle.api.Project
 
 class VariantConfigurator {
+    private final AndroidCommandPluginExtension extension
     private final Project project
     private final String taskName
     private final String description
     private final Class<? extends AdbTask> taskType
     private final def dependencies
-    private final AdbCommand adbCommand
 
-    VariantConfigurator(Project project,
-                        AdbCommand adbCommand,
+    VariantConfigurator(AndroidCommandPluginExtension extension,
+                        Project project,
                         String taskName,
                         String description,
                         Class<? extends AdbTask> taskType,
                         def dependencies) {
+        this.extension = extension
         this.project = project
-        this.adbCommand = adbCommand
         this.taskType = taskType
         this.taskName = taskName
         this.description = description
@@ -32,7 +32,9 @@ class VariantConfigurator {
 
         AdbTask task = project.tasks.create(taskName + variationName, taskType)
 
-        task.adbCommand = adbCommand
+        task.conventionMapping.adb = { extension.adb }
+        task.conventionMapping.aapt = { extension.aapt }
+        task.conventionMapping.deviceId = { extension.deviceId }
 
         if (task.pluginEx && task.pluginEx.sortBySubtasks) {
             task.group = AndroidCommandPlugin.TASK_GROUP + " " + taskName;


### PR DESCRIPTION
### Problem

The base class `AdbTask` had the `pluginExt` as a field and it was used extensively to access configuration properties of the extension of the plugin. 

We thought we should decouple this. Plugin is the one who creates the tasks. So it can give all the information that a task needs in its creation.

### Implementation details

- `pluginExt` is removed.
- undefined properties of tasks are resolved automatically by using `conventionMapping` in the configuration phase.
- We do this only for the tasks we create. This means that the tasks created by the user will not have conventionMapping set, which mean they would break. 
  - Therefore, for each access, we introduce a fallback method that resolves the fields by still accessing the extension.
  - This method is marked as deprecated and will be removed in the future.

> Paired with @tobiasheine 