### PR TITLE
Add a sample task to install all variants on 1 device.

### DIFF
--- a/sample/app/build.gradle
+++ b/sample/app/build.gradle
@@ -31,8 +31,12 @@ android {
 
     buildTypes {
         debug 
-        release
-        QA
+        release {
+            signingConfig debug.signingConfig
+        }
+        QA {
+            signingConfig debug.signingConfig
+        }
     }
 
     productFlavors {
@@ -122,6 +126,20 @@ android {
         task dumpActivityStack(type: com.novoda.gradle.command.ActivityStack) {
         }
     }
+}
+
+/**
+ * Sample task that installs APKs of all variants on a device.
+ *
+ * Device can also be specified like below:
+ * ./gradlew installDeviceAllVariants -DdeviceId=SERIAL_NUMBER
+ */
+def installAllTask = task installDeviceAllVariants {
+    description = 'Install APKs for all variants on a specified device'
+    group = 'install'
+}
+android.applicationVariants.all {
+    installAllTask.dependsOn tasks.findByName("installDevice${it.name.capitalize()}")
 }
 
 /**


### PR DESCRIPTION
This PR addresses #99 by implementing a sample that installs all variants on a single device.

We have also this issue #58 where we are talking about installing a single variant on **all** connected devices. They are kinda conflicting each other. It's technically possible but having both together can cause confusion. 

So I decided to include a sample that shows how quickly this can be done locally. It's up to us to close #99

Also added `signingConfig` to all buildTypes so that they can be installable