### PR TITLE
Fix nougat install

### DIFF
--- a/plugin/src/main/groovy/com/novoda/gradle/command/AdbTask.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/AdbTask.groovy
@@ -57,8 +57,14 @@ public class AdbTask extends org.gradle.api.DefaultTask {
         def adb = getAdb() ?: resolveFromExtension('adb')
         def deviceId = getDeviceId() ?: resolveFromExtension('deviceId')
         AdbCommand command = [adb: adb, deviceId: deviceId, parameters: parameters]
+
         logger.info "running command: $command"
-        handleCommandOutput(command.execute().text)
+
+        Process process = command.execute()
+        if (process.waitFor() != 0) {
+            throw new GroovyRuntimeException("Adb command failed with error:\n${process.err.text}");
+        }
+        handleCommandOutput(process.text)
     }
 
     protected handleCommandOutput(def text)  {

--- a/plugin/src/main/groovy/com/novoda/gradle/command/Install.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/Install.groovy
@@ -12,7 +12,7 @@ class Install extends AdbTask {
         if (getCustomFlags())
             arguments += getCustomFlags()
 
-        arguments += ['-rd', apkPath]
+        arguments += ['-r', '-d', apkPath]
 
         assertDeviceAndRunCommand(arguments)
     }


### PR DESCRIPTION
The install task is broken on Nougat devices. 

### Solution
Separate the arguments so that it works on Nougat devices. 

Combining different arguments was not a documented feature. It might be working on some devices, it might be ignored on some devices. Now it throws exception on Nougat devices because Nougat has a complete new implementation for adb shell interaction.

**Note:** Unfortunately again, it was a silent fail. It was trying to run after install fail, when we use `run` tasks.

So I decided to include a code piece that I had on my stash. It checks the exit code and errors accordingly. This feature will only work on Nougat devices but still it is useful for Nougat users.

Here is the output on a failure: 

![screen shot 2017-01-11 at 10 12 44 am](https://cloud.githubusercontent.com/assets/763339/21842520/7ad6f638-d7e7-11e6-83f6-afe67db6151b.png)

This PR fixes #108 