### PR TITLE
Add a root project name to the sample app

### DIFF
--- a/sample/settings.gradle
+++ b/sample/settings.gradle
@@ -1,1 +1,2 @@
+rootProject.name = 'gradle-android-command-plugin-sample'
 include ':app'


### PR DESCRIPTION
### Problem

We have couple of gradle plugin projects and the sample Android project cannot really be another module in the same project. 
So that's why our `sample` folder is another project. 
And because of that we have `sample`s everywhere. 

Here is how it looks like locally for me:

![pasted image at 2017_01_16 10_01 am](https://cloud.githubusercontent.com/assets/763339/21977043/d6b4e80c-dbd4-11e6-86ee-8333a9d73b43.png)

### Solution

Add root project name of the sample like below: 

`rootProject.name = 'gradle-android-command-plugin-sample'`