### PR TITLE
Update README to use Fully Qualified Name of the plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To start using this library, add these lines to the `build.gradle` of your proje
 
 ```groovy
 apply plugin: 'com.android.application'
-apply plugin: 'android-command'
+apply plugin: 'com.novoda.android-command'
 
 buildscript {
     repositories {

--- a/sample/app/build.gradle
+++ b/sample/app/build.gradle
@@ -3,30 +3,30 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.0'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         // To depend on the deployed version of the plugin add the following line here:
-        // classpath 'com.novoda:gradle-android-command-plugin:1.3.0'
+        // classpath 'com.novoda:gradle-android-command-plugin:{latest-version}'
     }
 }
 
 apply plugin: 'com.android.application'
-// apply android-command AFTER android plugin
-apply plugin: com.novoda.gradle.command.AndroidCommandPlugin
+// apply AFTER android plugin
+apply plugin: 'com.novoda.android-command'
 
 repositories {
     mavenCentral()
 }
 
 android {
-    compileSdkVersion 19
-    buildToolsVersion '22.0.1'
+    compileSdkVersion 25
+    buildToolsVersion '25.0.2'
 
     defaultConfig {
         versionCode 1
         versionName 'v0.0.1'
 
         minSdkVersion 14
-        targetSdkVersion 19
+        targetSdkVersion 25
     }
 
     buildTypes {
@@ -122,7 +122,7 @@ android {
                 return ['-i', 'com.android.vending']
             }
         }
-        
+
         task dumpActivityStack(type: com.novoda.gradle.command.ActivityStack) {
         }
     }


### PR DESCRIPTION
For a long time now, we support FQN with `com.novoda` package.
And that is how we use our other plugins. I thought it would be good to align.

- Update README to use FQN
- Update sample to have a usage similar to how people should use.
- Update Android SDK version