### PR TITLE
PT-429: input scripting

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ The plugin has a extension called `script` which allows you to do simple scripti
 Here is an example called `autoLogin` which will input the test username and password into the sample app.
 
 ```groovy
-inputScripts {
+scripts {
     autoLogin {
-        inputScript {
+        execute {
           2.times {
               text 'bob'
               enter()

--- a/README.md
+++ b/README.md
@@ -66,19 +66,20 @@ The plugin has a extension called `script` which allows you to do simple scripti
 Here is an example called `autoLogin` which will input the test username and password into the sample app.
 
 ```groovy
-script {
+inputScripts {
     autoLogin {
-        2.times {
-            text 'bob'
-            enter()
+        inputScript {
+          2.times {
+              text 'bob'
+              enter()
+          }
+          enter()
         }
-        enter()
     }
 }
 ```
 
-This config will create a gradle task called `autoLogin`. Running `./gradlew autoLogin` will try to input `bob` then press `enter`. This will be done
-2 times and then another `enter` will be pressed.
+This config will create a gradle task called `autoLogin`. Running `./gradlew autoLogin` will try to input `bob` then press `enter`. This will be done 2 times and then another `enter` will be pressed.
 
 You may have a custom groovy closure to do scripting as you like. The following input methods are available:
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
-# gradle-android-command-plugin 
+gradle-android-command-plugin
+=============================
 [![](https://ci.novoda.com/buildStatus/icon?job=gradle-android-command-plugin)](https://ci.novoda.com/job/gradle-android-command-plugin/lastSuccessfulBuild/console) [![](https://raw.githubusercontent.com/novoda/novoda/master/assets/btn_apache_lisence.png)](LICENSE.txt) [![Bintray](https://api.bintray.com/packages/novoda/maven/gradle-android-command-plugin/images/download.svg) ](https://bintray.com/novoda/maven/gradle-android-command-plugin/_latestVersion)
 
 Use gradle tasks to run specific `adb` commands.
 
 
-## Description
+Description
+-----------
 
 You can use this plugin to do things such as:
 
@@ -18,7 +20,8 @@ You can use this plugin to do things such as:
 This is particularly useful for CI servers but could be used to speed up development as well.
 
 
-## Adding to your project
+Adding to your project
+----------------------
 
 To start using this library, add these lines to the `build.gradle` of your project:
 
@@ -37,7 +40,8 @@ buildscript {
 ```
 
 
-## Simple usage
+Simple usage
+------------
 
 The plugin creates new tasks that you can use:
 
@@ -53,7 +57,52 @@ The plugin creates new tasks that you can use:
 
 For advanced usage please take a look into the sample project [build.gradle](sample/app/build.gradle) file.
 
-## Links
+Configuration
+-------------
+
+### Input Scripting
+
+The plugin has a extension called `script` which allows you to do simple scripting automation in a connected device.
+Here is an example called `autoLogin` which will input the test username and password into the sample app.
+
+```groovy
+script {
+    autoLogin {
+        2.times {
+            text 'bob'
+            enter()
+        }
+        enter()
+    }
+}
+```
+
+This config will create a gradle task called `autoLogin`. Running `./gradlew autoLogin` will try to input `bob` then press `enter`. This will be done
+2 times and then another `enter` will be pressed.
+
+You may have a custom groovy closure to do scripting as you like. The following input methods are available:
+
+```
+text(String value)
+tap(int x, int y)
+swipe(int startX, int startY, int endX, int endY)
+key(int code)
+home()
+back()
+up()
+down()
+left()
+right()
+clear()
+tab()
+enter()
+power()
+unlock()
+```
+
+
+Links
+-----
 
 Here are a list of useful links:
 

--- a/plugin/src/main/groovy/com/novoda/gradle/command/AndroidCommandPlugin.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/AndroidCommandPlugin.groovy
@@ -40,12 +40,12 @@ public class AndroidCommandPlugin implements Plugin<Project> {
         }
     }
 
-    private configureInputScripts(AndroidCommandPluginExtension extension, Project project) {
-        extension.scripts.all { input ->
-            project.tasks.create(input.name, Input) {
+    private configureInputScripts(AndroidCommandPluginExtension command, Project project) {
+        command.scripts.all { extension ->
+            project.tasks.create(extension.name, Input) {
                 group = 'adb script'
-                description = "Runs $input.name script on the specified device"
-                inputSpec = input
+                description = "Runs $extension.name script on the specified device"
+                inputExtension = extension
             }
         }
     }

--- a/plugin/src/main/groovy/com/novoda/gradle/command/AndroidCommandPlugin.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/AndroidCommandPlugin.groovy
@@ -45,7 +45,7 @@ public class AndroidCommandPlugin implements Plugin<Project> {
             project.tasks.create(input.name, Input) {
                 group = 'adb script'
                 description = "Runs $input.name script on the specified device"
-                script = input
+                inputSpec = input
             }
         }
     }

--- a/plugin/src/main/groovy/com/novoda/gradle/command/AndroidCommandPlugin.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/AndroidCommandPlugin.groovy
@@ -26,6 +26,8 @@ public class AndroidCommandPlugin implements Plugin<Project> {
             conventionMapping.monkey = { extension.monkey }
         }
 
+        configureInputScripts(extension, project)
+
         defaultTask (project, 'enableSystemAnimations', 'enables system animations on the connected device', SystemAnimations) {
             enable = true
         }
@@ -38,7 +40,17 @@ public class AndroidCommandPlugin implements Plugin<Project> {
         }
     }
 
-    static def defaultTask(Project project, String taskName, String description, Class<? extends AdbTask> taskType, Closure configuration) {
+    private configureInputScripts(AndroidCommandPluginExtension extension, Project project) {
+        extension.scripts.all { input ->
+            project.tasks.create(input.name, Input) {
+                group = 'adb script'
+                description = "Runs $input.name script on the specified device"
+                script = input
+            }
+        }
+    }
+
+    static defaultTask(Project project, String taskName, String description, Class<? extends AdbTask> taskType, Closure configuration) {
         AdbTask task = project.tasks.create(taskName, taskType)
         task.configure configuration
         task.group = TASK_GROUP

--- a/plugin/src/main/groovy/com/novoda/gradle/command/AndroidCommandPluginExtension.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/AndroidCommandPluginExtension.groovy
@@ -2,6 +2,7 @@ package com.novoda.gradle.command
 
 import groovy.transform.Memoized
 import org.gradle.api.Action
+import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Project
 
 public class AndroidCommandPluginExtension {
@@ -14,6 +15,7 @@ public class AndroidCommandPluginExtension {
     private final Project project
     private final String androidHome
     private final MonkeySpec monkey
+    private final NamedDomainObjectContainer<InputSpec> scripts
 
     AndroidCommandPluginExtension(Project project) {
         this(project, findAndroidHomeFrom(project.android))
@@ -23,6 +25,7 @@ public class AndroidCommandPluginExtension {
         this.project = project
         this.androidHome = androidHome
         this.monkey = new MonkeySpec()
+        this.scripts = project.container(InputSpec)
     }
 
     def task(String name, Class<? extends AdbTask> type, Closure configuration) {
@@ -81,6 +84,14 @@ public class AndroidCommandPluginExtension {
 
     MonkeySpec getMonkey() {
         monkey
+    }
+
+    void script(Action<NamedDomainObjectContainer<InputSpec>> action) {
+        action.execute(scripts)
+    }
+
+    NamedDomainObjectContainer<InputSpec> getScripts() {
+        scripts
     }
 
     void attachDefaults(AdbTask task) {

--- a/plugin/src/main/groovy/com/novoda/gradle/command/AndroidCommandPluginExtension.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/AndroidCommandPluginExtension.groovy
@@ -86,7 +86,7 @@ public class AndroidCommandPluginExtension {
         monkey
     }
 
-    void inputScripts(Closure script) {
+    void scripts(Closure script) {
         scripts.configure(script)
     }
 

--- a/plugin/src/main/groovy/com/novoda/gradle/command/AndroidCommandPluginExtension.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/AndroidCommandPluginExtension.groovy
@@ -15,7 +15,7 @@ public class AndroidCommandPluginExtension {
     private final Project project
     private final String androidHome
     private final MonkeySpec monkey
-    private final NamedDomainObjectContainer<InputSpec> scripts
+    private final NamedDomainObjectContainer<InputExtension> scriptsContainer
 
     AndroidCommandPluginExtension(Project project) {
         this(project, findAndroidHomeFrom(project.android))
@@ -25,7 +25,7 @@ public class AndroidCommandPluginExtension {
         this.project = project
         this.androidHome = androidHome
         this.monkey = new MonkeySpec()
-        this.scripts = project.container(InputSpec)
+        this.scriptsContainer = project.container(InputExtension)
     }
 
     def task(String name, Class<? extends AdbTask> type, Closure configuration) {
@@ -86,12 +86,12 @@ public class AndroidCommandPluginExtension {
         monkey
     }
 
-    void scripts(Closure script) {
-        scripts.configure(script)
+    void scripts(Action<NamedDomainObjectContainer<InputExtension>> script) {
+        script.execute(scriptsContainer)
     }
 
-    NamedDomainObjectContainer<InputSpec> getScripts() {
-        scripts
+    NamedDomainObjectContainer<InputExtension> getScripts() {
+        scriptsContainer
     }
 
     void attachDefaults(AdbTask task) {

--- a/plugin/src/main/groovy/com/novoda/gradle/command/AndroidCommandPluginExtension.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/AndroidCommandPluginExtension.groovy
@@ -86,8 +86,8 @@ public class AndroidCommandPluginExtension {
         monkey
     }
 
-    void script(Action<NamedDomainObjectContainer<InputSpec>> action) {
-        action.execute(scripts)
+    void inputScripts(Closure script) {
+        scripts.configure(script)
     }
 
     NamedDomainObjectContainer<InputSpec> getScripts() {

--- a/plugin/src/main/groovy/com/novoda/gradle/command/Input.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/Input.groovy
@@ -4,7 +4,7 @@ import org.gradle.api.tasks.TaskAction
 
 class Input extends AdbTask {
 
-    InputSpec inputSpec
+    InputExtension inputExtension
 
     /**
      * Manual creation of Input task is deprecated.
@@ -18,8 +18,8 @@ class Input extends AdbTask {
                        Please refer to scripting documentation to modify your task '$name'
                        https://github.com/novoda/gradle-android-command-plugin#input-scripting
                        """.stripIndent()
-        inputSpec = new InputSpec()
-        inputSpec.script = script
+        inputExtension = new InputExtension()
+        inputExtension.script = script
     }
 
     void text(String value) {
@@ -89,7 +89,7 @@ class Input extends AdbTask {
     @TaskAction
     void exec() {
         assertDeviceConnected()
-        inputSpec.script.delegate = this
-        inputSpec.script.call()
+        inputExtension.script.delegate = this
+        inputExtension.script.call()
     }
 }

--- a/plugin/src/main/groovy/com/novoda/gradle/command/Input.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/Input.groovy
@@ -1,80 +1,27 @@
 package com.novoda.gradle.command
 
+import org.gradle.api.Action
 import org.gradle.api.tasks.TaskAction
 
 class Input extends AdbTask {
 
-    Closure script
+    InputSpec script = new InputSpec()
 
-    void text(String value) {
-        input('text', "$value")
-    }
-
-    void tap(int x, int y) {
-        input('touchscreen', 'tap', x, y)
-    }
-
-    void swipe(int startX, int startY, int endX, int endY) {
-        input('touchscreen', 'swipe', startX, startY, endX, endY)
-    }
-
-    void key(int code) {
-        input('keyevent', code)
-    }
-    
-    void home() {
-        key 3
-    }
-    
-    void back() {
-        key 4
-    }
-
-    void up() {
-        key 19
-    }
-
-    void down() {
-        key 20
-    }
-    
-    void left() {
-        key 21
-    }
-
-    void right() {
-        key 22
-    }
-
-    void power() {
-        key 26
-    }
-    
-    void clear() {
-        key 28
-    }
-
-    void tab() {
-        key 61
-    }
-    
-    void enter() {
-        key 66
-    }
-
-    void unlock() {
-        key 82
-    }
-
-    private input(... values) {
-        def command = ["shell", "input"]
-        command.addAll(values)
-        runCommand(command)
+    @Deprecated
+    void script(Action<InputSpec> action) {
+        logger.warn """\
+                       Manual creation of Input task is deprecated.
+                       Please refer to scripting documentation to modify your task '$name'
+                       https://github.com/novoda/gradle-android-command-plugin#scripting
+                       """.stripIndent()
+        action.execute(script)
     }
 
     @TaskAction
     void exec() {
         assertDeviceConnected()
-        script.call()
+        script.commands.each {
+            runCommand(it)
+        }
     }
 }

--- a/plugin/src/main/groovy/com/novoda/gradle/command/Input.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/Input.groovy
@@ -19,7 +19,7 @@ class Input extends AdbTask {
                        https://github.com/novoda/gradle-android-command-plugin#input-scripting
                        """.stripIndent()
         inputSpec = new InputSpec()
-        inputSpec.inputScript = script
+        inputSpec.script = script
     }
 
     void text(String value) {
@@ -89,7 +89,7 @@ class Input extends AdbTask {
     @TaskAction
     void exec() {
         assertDeviceConnected()
-        inputSpec.inputScript.delegate = this
-        inputSpec.inputScript.call()
+        inputSpec.script.delegate = this
+        inputSpec.script.call()
     }
 }

--- a/plugin/src/main/groovy/com/novoda/gradle/command/Input.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/Input.groovy
@@ -1,27 +1,95 @@
 package com.novoda.gradle.command
 
-import org.gradle.api.Action
 import org.gradle.api.tasks.TaskAction
 
 class Input extends AdbTask {
 
-    InputSpec script = new InputSpec()
+    InputSpec inputSpec
 
+    /**
+     * Manual creation of Input task is deprecated.
+     * Please refer to scripting documentation for details:
+     * https://github.com/novoda/gradle-android-command-plugin#input-scripting
+     */
     @Deprecated
-    void script(Action<InputSpec> action) {
+    void setScript(Closure script) {
         logger.warn """\
                        Manual creation of Input task is deprecated.
                        Please refer to scripting documentation to modify your task '$name'
                        https://github.com/novoda/gradle-android-command-plugin#input-scripting
                        """.stripIndent()
-        action.execute(script)
+        inputSpec = new InputSpec()
+        inputSpec.inputScript = script
+    }
+
+    void text(String value) {
+        input('text', "$value")
+    }
+
+    void tap(int x, int y) {
+        input('touchscreen', 'tap', x, y)
+    }
+
+    void swipe(int startX, int startY, int endX, int endY) {
+        input('touchscreen', 'swipe', startX, startY, endX, endY)
+    }
+
+    void key(int code) {
+        input('keyevent', code)
+    }
+
+    void home() {
+        key 3
+    }
+
+    void back() {
+        key 4
+    }
+
+    void up() {
+        key 19
+    }
+
+    void down() {
+        key 20
+    }
+
+    void left() {
+        key 21
+    }
+
+    void right() {
+        key 22
+    }
+
+    void power() {
+        key 26
+    }
+
+    void clear() {
+        key 28
+    }
+
+    void tab() {
+        key 61
+    }
+
+    void enter() {
+        key 66
+    }
+
+    void unlock() {
+        key 82
+    }
+
+    private input(... values) {
+        runCommand(['shell', 'input', *values])
     }
 
     @TaskAction
     void exec() {
         assertDeviceConnected()
-        script.commands.each {
-            runCommand(it)
-        }
+        inputSpec.inputScript.delegate = this
+        inputSpec.inputScript.call()
     }
 }

--- a/plugin/src/main/groovy/com/novoda/gradle/command/Input.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/Input.groovy
@@ -12,7 +12,7 @@ class Input extends AdbTask {
         logger.warn """\
                        Manual creation of Input task is deprecated.
                        Please refer to scripting documentation to modify your task '$name'
-                       https://github.com/novoda/gradle-android-command-plugin#scripting
+                       https://github.com/novoda/gradle-android-command-plugin#input-scripting
                        """.stripIndent()
         action.execute(script)
     }

--- a/plugin/src/main/groovy/com/novoda/gradle/command/InputExtension.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/InputExtension.groovy
@@ -1,11 +1,11 @@
 package com.novoda.gradle.command
 
-class InputSpec {
+class InputExtension {
 
     String name
     Closure script
 
-    InputSpec(name) {
+    InputExtension(name) {
         this.name = name
     }
 

--- a/plugin/src/main/groovy/com/novoda/gradle/command/InputSpec.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/InputSpec.groovy
@@ -49,10 +49,6 @@ class InputSpec {
         key 22
     }
 
-    void power() {
-        key 26
-    }
-
     void clear() {
         key 28
     }
@@ -63,6 +59,10 @@ class InputSpec {
 
     void enter() {
         key 66
+    }
+
+    void power() {
+        key 26
     }
 
     void unlock() {

--- a/plugin/src/main/groovy/com/novoda/gradle/command/InputSpec.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/InputSpec.groovy
@@ -3,14 +3,14 @@ package com.novoda.gradle.command
 class InputSpec {
 
     String name
-    Closure inputScript
+    Closure script
 
     InputSpec(name) {
         this.name = name
     }
 
-    void inputScript(inputScript) {
-        this.inputScript = inputScript
+    void execute(script) {
+        this.script = script
     }
 
 }

--- a/plugin/src/main/groovy/com/novoda/gradle/command/InputSpec.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/InputSpec.groovy
@@ -1,77 +1,16 @@
-package com.novoda.gradle.command;
+package com.novoda.gradle.command
 
 class InputSpec {
 
-    final String name
-    final List commands = []
+    String name
+    Closure inputScript
 
     InputSpec(name) {
         this.name = name
     }
 
-    void text(String value) {
-        input('text', "$value")
+    void inputScript(inputScript) {
+        this.inputScript = inputScript
     }
 
-    void tap(int x, int y) {
-        input('touchscreen', 'tap', x, y)
-    }
-
-    void swipe(int startX, int startY, int endX, int endY) {
-        input('touchscreen', 'swipe', startX, startY, endX, endY)
-    }
-
-    void key(int code) {
-        input('keyevent', code)
-    }
-
-    void home() {
-        key 3
-    }
-
-    void back() {
-        key 4
-    }
-
-    void up() {
-        key 19
-    }
-
-    void down() {
-        key 20
-    }
-
-    void left() {
-        key 21
-    }
-
-    void right() {
-        key 22
-    }
-
-    void clear() {
-        key 28
-    }
-
-    void tab() {
-        key 61
-    }
-
-    void enter() {
-        key 66
-    }
-
-    void power() {
-        key 26
-    }
-
-    void unlock() {
-        key 82
-    }
-
-    private input(... values) {
-        List command = ['shell', 'input']
-        command.addAll(values)
-        commands << command
-    }
 }

--- a/plugin/src/main/groovy/com/novoda/gradle/command/InputSpec.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/InputSpec.groovy
@@ -1,0 +1,77 @@
+package com.novoda.gradle.command;
+
+class InputSpec {
+
+    final String name
+    final List commands = []
+
+    InputSpec(name) {
+        this.name = name
+    }
+
+    void text(String value) {
+        input('text', "$value")
+    }
+
+    void tap(int x, int y) {
+        input('touchscreen', 'tap', x, y)
+    }
+
+    void swipe(int startX, int startY, int endX, int endY) {
+        input('touchscreen', 'swipe', startX, startY, endX, endY)
+    }
+
+    void key(int code) {
+        input('keyevent', code)
+    }
+
+    void home() {
+        key 3
+    }
+
+    void back() {
+        key 4
+    }
+
+    void up() {
+        key 19
+    }
+
+    void down() {
+        key 20
+    }
+
+    void left() {
+        key 21
+    }
+
+    void right() {
+        key 22
+    }
+
+    void power() {
+        key 26
+    }
+
+    void clear() {
+        key 28
+    }
+
+    void tab() {
+        key 61
+    }
+
+    void enter() {
+        key 66
+    }
+
+    void unlock() {
+        key 82
+    }
+
+    private input(... values) {
+        List command = ['shell', 'input']
+        command.addAll(values)
+        commands << command
+    }
+}

--- a/sample/app/build.gradle
+++ b/sample/app/build.gradle
@@ -99,13 +99,15 @@ android {
             }
         }
 
-        script {
+        inputScripts {
             autoLogin {
-                2.times {
-                    text 'bob'
+                inputScript {
+                    2.times {
+                        text 'bob'
+                        enter()
+                    }
                     enter()
                 }
-                enter()
             }
         }
 

--- a/sample/app/build.gradle
+++ b/sample/app/build.gradle
@@ -99,8 +99,8 @@ android {
             }
         }
 
-        task autoLogin(type: com.novoda.gradle.command.Input) {
-            script {
+        script {
+            autoLogin {
                 2.times {
                     text 'bob'
                     enter()

--- a/sample/app/build.gradle
+++ b/sample/app/build.gradle
@@ -99,9 +99,9 @@ android {
             }
         }
 
-        inputScripts {
+        scripts {
             autoLogin {
-                inputScript {
+                execute {
                     2.times {
                         text 'bob'
                         enter()

--- a/sample/app/build.gradle
+++ b/sample/app/build.gradle
@@ -109,6 +109,10 @@ android {
                     enter()
                 }
             }
+
+            pressBack.execute {
+                back()
+            }
         }
 
         task listDevices doLast {


### PR DESCRIPTION
## Problem

Currently, user has to create a new task extending from Input to have input scripting. It doesn't really look good and we don't have much control over that task since we don't create it ourselves. 

## Solution

This is a proposal of a possible solution. I would like to get opinions and structure possible follow-ups for other tasks. 

A `NamedDomainObjectContainer` is introduced in the extension. This is what `productFlavors` use in Android. This will allow users to have scripts like below

```groovy
scripts {
    autoLogin {
        execute {
            2.times {
                text 'bob'
                enter()
            }
            enter()
        }
    }
}
```

This will then create an `InputSpec` object which will holds a `Closure` to be lazily executed in runtime of the task.

For backward compatibility, `Closure script` in `Input` task is not removed. But instead it now uses `InputSpec` as an inner field. `script` is converted to `write-only` property to keep backward compatibility. When called, prints a warning with a link to the appropriate section in README. 

Deprecation is even visible to users in their `build.gradle` files

![](https://user-images.githubusercontent.com/763339/34680151-79c6117e-f498-11e7-91ae-efb51ff18731.png)
  