### PR TITLE
Demo mode extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,28 @@ power()
 unlock()
 ```
 
+### Demo Mode
+
+`[enable|disable]DemoMode` tasks are create to control demo mode on Android Marshmallow (API level 23) devices.
+
+By default these tasks setup the demo mode with most common used default values. And they can be controlled with `demoMode` DSL.
+
+```groovy          
+demoMode {
+    battery {
+        level '100'
+        plugged 'false'
+    }
+    network {
+        wifi 'show'
+        level '4'
+    }
+    clock.hhmm '0810'
+    notifications.visible 'false'
+}
+``` 
+
+All possible values can be found in [the official Android documentation](https://android.googlesource.com/platform/frameworks/base/+/master/packages/SystemUI/docs/demo_mode.md)
 
 Links
 -----

--- a/plugin/src/main/groovy/com/novoda/gradle/command/AdbTask.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/AdbTask.groovy
@@ -21,6 +21,10 @@ public class AdbTask extends org.gradle.api.DefaultTask {
         deviceId
     }
 
+    Device device() {
+        new Device(getAdb(), getDeviceId())
+    }
+
     def getPackageName() {
         def output = readApkProperty('package')
         if (output) {

--- a/plugin/src/main/groovy/com/novoda/gradle/command/AndroidCommandPlugin.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/AndroidCommandPlugin.groovy
@@ -34,10 +34,19 @@ public class AndroidCommandPlugin implements Plugin<Project> {
         defaultTask (project, 'disableSystemAnimations', 'disables system animations on the connected device', SystemAnimations) {
             enable = false
         }
+        configureDemoMode(project, extension.demoModeContainer)
 
         project.tasks.withType(AdbTask) { task ->
             extension.attachDefaults(task)
         }
+    }
+
+    private void configureDemoMode(Project project, demoModeContainer) {
+        project.tasks.create('enableDemoMode', DemoModeTask) {
+            enable = true
+            commands = demoModeContainer
+        }
+        project.tasks.create('disableDemoMode', DemoModeTask) { enable = false }
     }
 
     private configureInputScripts(AndroidCommandPluginExtension command, Project project) {

--- a/plugin/src/main/groovy/com/novoda/gradle/command/AndroidCommandPlugin.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/AndroidCommandPlugin.groovy
@@ -42,11 +42,10 @@ public class AndroidCommandPlugin implements Plugin<Project> {
     }
 
     private void configureDemoMode(Project project, demoModeContainer) {
-        project.tasks.create('enableDemoMode', DemoModeTask) {
-            enable = true
+        project.tasks.create('enableDemoMode', EnableDemoModeTask) {
             commands = demoModeContainer
         }
-        project.tasks.create('disableDemoMode', DemoModeTask) { enable = false }
+        project.tasks.create('disableDemoMode', DisableDemoModeTask)
     }
 
     private configureInputScripts(AndroidCommandPluginExtension command, Project project) {

--- a/plugin/src/main/groovy/com/novoda/gradle/command/AndroidCommandPluginExtension.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/AndroidCommandPluginExtension.groovy
@@ -106,13 +106,13 @@ public class AndroidCommandPluginExtension {
         task.conventionMapping.deviceId = { getDeviceId() }
     }
 
-    def devices() {
+    List<Device> devices() {
         deviceIds().collect { deviceId ->
             new Device(getAdb(), deviceId)
         }
     }
 
-    def deviceIds() {
+    List<String> deviceIds() {
         def deviceIds = []
         [getAdb(), 'devices'].execute().text.eachLine { line ->
             def matcher = line =~ /^(.*)\tdevice/

--- a/plugin/src/main/groovy/com/novoda/gradle/command/AndroidCommandPluginExtension.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/AndroidCommandPluginExtension.groovy
@@ -16,6 +16,7 @@ public class AndroidCommandPluginExtension {
     private final String androidHome
     private final MonkeySpec monkey
     private final NamedDomainObjectContainer<InputExtension> scriptsContainer
+    final NamedDomainObjectContainer<DemoModeExtension> demoModeContainer
 
     AndroidCommandPluginExtension(Project project) {
         this(project, findAndroidHomeFrom(project.android))
@@ -25,6 +26,7 @@ public class AndroidCommandPluginExtension {
         this.project = project
         this.androidHome = androidHome
         this.monkey = new MonkeySpec()
+        this.demoModeContainer = project.container(DemoModeExtension)
         this.scriptsContainer = project.container(InputExtension)
     }
 
@@ -84,6 +86,10 @@ public class AndroidCommandPluginExtension {
 
     MonkeySpec getMonkey() {
         monkey
+    }
+
+    void demoMode(Action<NamedDomainObjectContainer<DemoModeExtension>> action) {
+        action.execute(demoModeContainer)
     }
 
     void scripts(Action<NamedDomainObjectContainer<InputExtension>> script) {

--- a/plugin/src/main/groovy/com/novoda/gradle/command/DemoModeExtension.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/DemoModeExtension.groovy
@@ -1,0 +1,19 @@
+package com.novoda.gradle.command
+
+class DemoModeExtension {
+
+    final name
+    final extras = new HashMap<String, String>()
+
+    DemoModeExtension(name) {
+        this.name = name
+    }
+
+    def methodMissing(String name, args) {
+        extras[name] = args[0]
+    }
+
+    def propertyMissing(String name, value) {
+        extras[name] = value
+    }
+}

--- a/plugin/src/main/groovy/com/novoda/gradle/command/DemoModeExtension.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/DemoModeExtension.groovy
@@ -3,7 +3,7 @@ package com.novoda.gradle.command
 class DemoModeExtension {
 
     final name
-    final extras = new HashMap<String, String>()
+    final extras = [:]
 
     DemoModeExtension(name) {
         this.name = name

--- a/plugin/src/main/groovy/com/novoda/gradle/command/DemoModeTask.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/DemoModeTask.groovy
@@ -16,7 +16,7 @@ class DemoModeTask extends AdbTask {
     @TaskAction
     void exec() {
         assertDeviceConnected()
-        assertDeviceAndroidM()
+        assertDeviceAtLeastAndroidM()
         if (enable) {
             allowDemoMode()
             executeDefaults()
@@ -56,7 +56,7 @@ class DemoModeTask extends AdbTask {
         ])
     }
 
-    void assertDeviceAndroidM() {
+    void assertDeviceAtLeastAndroidM() {
         if (device().sdkVersion() < 23) {
             logger.warn "Connected device must have at least Android Marshmallow (API level 23) to enable Demo Mode"
         }

--- a/plugin/src/main/groovy/com/novoda/gradle/command/DemoModeTask.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/DemoModeTask.groovy
@@ -22,7 +22,6 @@ class DemoModeTask extends AdbTask {
             commands.each {
                 broadcast it.name, it.extras
             }
-
         } else {
             broadcast 'exit'
         }
@@ -40,7 +39,7 @@ class DemoModeTask extends AdbTask {
         runCommand(['shell', 'settings', 'put', 'global', 'sysui_demo_allowed', '1'])
     }
 
-    def broadcastDefault(String name, Map<String, String> intentExtras) {
+    def broadcastDefault(String name, intentExtras) {
         if (!commands.findByName(name)) {
             broadcast(name, intentExtras)
         }

--- a/plugin/src/main/groovy/com/novoda/gradle/command/DemoModeTask.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/DemoModeTask.groovy
@@ -47,7 +47,7 @@ class DemoModeTask extends AdbTask {
         }
     }
 
-    def broadcast(String name, Map<String, String> intentExtras) {
+    def broadcast(String name, Map<String, String> intentExtras = [:]) {
         def args = intentExtras.collectMany { key, value -> ['-e', "$key", "$value"] }
         runCommand([
                 'shell', 'am', 'broadcast',

--- a/plugin/src/main/groovy/com/novoda/gradle/command/DemoModeTask.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/DemoModeTask.groovy
@@ -1,0 +1,58 @@
+package com.novoda.gradle.command
+
+import org.gradle.api.NamedDomainObjectContainer
+import org.gradle.api.tasks.TaskAction
+
+class DemoModeTask extends AdbTask {
+
+    boolean enable
+    NamedDomainObjectContainer<DemoModeExtension> commands
+
+    DemoModeTask() {
+        this.group = AndroidCommandPlugin.TASK_GROUP
+        this.description = "${enable ? 'Enables' : 'Disables'} demo mode on the connected device"
+    }
+
+    @TaskAction
+    void exec() {
+        assertDeviceConnected()
+        if (enable) {
+            allowDemoMode()
+            executeDefaults()
+            commands.each {
+                broadcast it.name, it.extras
+            }
+
+        } else {
+            broadcast 'exit'
+        }
+    }
+
+    private void executeDefaults() {
+        broadcastDefault 'network', [mobile: 'show', level: '4']
+        broadcastDefault 'battery', [level: '100', plugged: 'false']
+        broadcastDefault 'network', [wifi: 'show', level: '4']
+        broadcastDefault 'clock', [hhmm: '0810']
+        broadcastDefault 'notifications', [visible: 'false']
+    }
+
+    private void allowDemoMode() {
+        runCommand(['shell', 'settings', 'put', 'global', 'sysui_demo_allowed', '1'])
+    }
+
+    def broadcastDefault(String name, Map<String, String> intentExtras) {
+        if (!commands.findByName(name)) {
+            broadcast(name, intentExtras)
+        }
+    }
+
+    def broadcast(String name, Map<String, String> intentExtras) {
+        def args = intentExtras.collectMany { key, value -> ['-e', "$key", "$value"] }
+        runCommand([
+                'shell', 'am', 'broadcast',
+                '-a', 'com.android.systemui.demo',
+                '-e', 'command', name,
+                *args
+        ])
+    }
+}

--- a/plugin/src/main/groovy/com/novoda/gradle/command/DemoModeTask.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/DemoModeTask.groovy
@@ -1,5 +1,6 @@
 package com.novoda.gradle.command
 
+import org.gradle.api.GradleException
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.tasks.TaskAction
 
@@ -16,6 +17,7 @@ class DemoModeTask extends AdbTask {
     @TaskAction
     void exec() {
         assertDeviceConnected()
+        assertDeviceAndroidM()
         if (enable) {
             allowDemoMode()
             executeDefaults()
@@ -53,5 +55,11 @@ class DemoModeTask extends AdbTask {
                 '-e', 'command', name,
                 *args
         ])
+    }
+
+    void assertDeviceAndroidM() {
+        if (device().sdkVersion() < 23) {
+            throw new GradleException("Connected device must have at least Android Marshmallow (API level 23)")
+        }
     }
 }

--- a/plugin/src/main/groovy/com/novoda/gradle/command/DemoModeTask.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/DemoModeTask.groovy
@@ -1,6 +1,5 @@
 package com.novoda.gradle.command
 
-import org.gradle.api.GradleException
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.tasks.TaskAction
 
@@ -59,7 +58,7 @@ class DemoModeTask extends AdbTask {
 
     void assertDeviceAndroidM() {
         if (device().sdkVersion() < 23) {
-            throw new GradleException("Connected device must have at least Android Marshmallow (API level 23)")
+            logger.warn "Connected device must have at least Android Marshmallow (API level 23) to enable Demo Mode"
         }
     }
 }

--- a/plugin/src/main/groovy/com/novoda/gradle/command/DisableDemoModeTask.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/DisableDemoModeTask.groovy
@@ -1,0 +1,23 @@
+package com.novoda.gradle.command
+
+import groovy.transform.PackageScope
+import org.gradle.api.tasks.TaskAction
+
+@PackageScope
+class DisableDemoModeTask extends AdbTask {
+
+    DisableDemoModeTask() {
+        this.group = AndroidCommandPlugin.TASK_GROUP
+        this.description = "Disables demo mode on the device"
+    }
+
+    @TaskAction
+    void exec() {
+        assertDeviceConnected()
+        runCommand([
+                'shell', 'am', 'broadcast',
+                '-a', 'com.android.systemui.demo',
+                '-e', 'command', 'exit'
+        ])
+    }
+}

--- a/plugin/src/main/groovy/com/novoda/gradle/command/SystemAnimations.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/SystemAnimations.groovy
@@ -4,29 +4,29 @@ import org.gradle.api.tasks.TaskAction
 
 class SystemAnimations extends AdbTask {
 
-  Boolean enable;
+    boolean enable
 
-  @TaskAction
-  void exec() {
-    assertDeviceConnected()
-    windowAnimations()
-    transitionAnimations()
-    animatorDuration()
-  }
+    @TaskAction
+    void exec() {
+        assertDeviceConnected()
+        windowAnimations()
+        transitionAnimations()
+        animatorDuration()
+    }
 
-  private windowAnimations() {
-    def arguments = ['shell', 'settings', 'put', 'global', 'window_animation_scale', enable ? '1' : '0']
-    runCommand(arguments)
-  }
+    private windowAnimations() {
+        def arguments = ['shell', 'settings', 'put', 'global', 'window_animation_scale', enable ? '1' : '0']
+        runCommand(arguments)
+    }
 
-  private transitionAnimations() {
-    def arguments = ['shell', 'settings', 'put', 'global', 'transition_animation_scale', enable ? '1' : '0']
-    runCommand(arguments)
-  }
+    private transitionAnimations() {
+        def arguments = ['shell', 'settings', 'put', 'global', 'transition_animation_scale', enable ? '1' : '0']
+        runCommand(arguments)
+    }
 
-  private animatorDuration() {
-    def arguments = ['shell', 'settings', 'put', 'global', 'animator_duration_scale', enable ? '1' : '0']
-    runCommand(arguments)
-  }
+    private animatorDuration() {
+        def arguments = ['shell', 'settings', 'put', 'global', 'animator_duration_scale', enable ? '1' : '0']
+        runCommand(arguments)
+    }
 
 }

--- a/plugin/src/main/groovy/com/novoda/gradle/command/SystemAnimations.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/SystemAnimations.groovy
@@ -1,7 +1,9 @@
 package com.novoda.gradle.command
 
+import groovy.transform.PackageScope
 import org.gradle.api.tasks.TaskAction
 
+@PackageScope
 class SystemAnimations extends AdbTask {
 
     boolean enable

--- a/sample/app/build.gradle
+++ b/sample/app/build.gradle
@@ -99,14 +99,7 @@ android {
             }
         }
 
-        demoMode {
-            clock.hhmm '1134'
-            network {
-                wifi 'show'
-                level '3'
-            }
-        }
-
+        // More info: https://github.com/novoda/gradle-android-command-plugin#input-scripting
         scripts {
             autoLogin {
                 execute {
@@ -120,6 +113,15 @@ android {
 
             pressBack.execute {
                 back()
+            }
+        }
+
+        // More info: https://github.com/novoda/gradle-android-command-plugin#demo-mode
+        demoMode {
+            clock.hhmm '1134'
+            network {
+                wifi 'show'
+                level '3'
             }
         }
 

--- a/sample/app/build.gradle
+++ b/sample/app/build.gradle
@@ -99,6 +99,14 @@ android {
             }
         }
 
+        demoMode {
+            clock.hhmm '1134'
+            network {
+                wifi 'show'
+                level '3'
+            }
+        }
+
         scripts {
             autoLogin {
                 execute {


### PR DESCRIPTION
This PR adds `enableDemoMode` & `disableDemoMode` tasks which interacts with Android Marshmallow's Demo Mode

More information about demo mode can be found here:
[User facing side of things](http://www.androidpolice.com/2015/07/19/android-m-feature-spotlight-demo-mode-hides-notifications-sets-battery-to-100-and-clock-to-520-perfect-for-screenshots/)
[Developer documentation](https://android.googlesource.com/platform/frameworks/base/+/android-6.0.0_r1/packages/SystemUI/docs/demo_mode.md)

This PR adds `demoMode` extension that allows you to control anything defined in the above document in a nice dsl. 

### Example:

```groovy
demoMode {
    clock.hhmm '1134'
    network {
        wifi 'show'
        level '3'
    }
}
```

### Default config

If not defined, below is the default configuration I set. And any user defined configuration will override the default values. 

```groovy
demoMode {
        network {
            mobile 'show'
            level '4'
        }
        battery {
            level '100'
            plugged 'false'
        }
        network {
            wifi 'show'
            level '4'
        }
        clock.hhmm '0810'
        notifications.visible 'false'
}
```

### Live Action

![demomode](https://user-images.githubusercontent.com/763339/35432879-ce3f2eba-0281-11e8-9834-64a214b9d378.gif)
