### PR TITLE
Clean-up extension

### DIFF
--- a/plugin/src/main/groovy/com/novoda/gradle/command/ActivityStack.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/ActivityStack.groovy
@@ -13,8 +13,6 @@ class ActivityStack extends AdbTask {
 
     def getActivityRecords() {
         def commandLine = ['shell', 'dumpsys', 'activity', '|', 'grep', '-i', 'run']
-        def adb = this.adb ?: resolveFromExtension('adb')
-        def deviceId = this.deviceId ?: resolveFromExtension('deviceId')
         AdbCommand command = [adb: adb, deviceId: deviceId, parameters: commandLine]
         logger.info "running command: $command"
         def output = command.execute().text

--- a/plugin/src/main/groovy/com/novoda/gradle/command/AndroidCommandPlugin.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/AndroidCommandPlugin.groovy
@@ -1,5 +1,6 @@
 package com.novoda.gradle.command
 
+import org.gradle.api.DomainObjectCollection
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.tasks.StopExecutionException
@@ -29,25 +30,10 @@ class AndroidCommandPlugin implements Plugin<Project> {
         }
 
         configureInputScripts(extension, project)
-
-        defaultTask(project, 'enableSystemAnimations', 'enables system animations on the connected device', SystemAnimations) {
-            enable = true
-        }
-        defaultTask(project, 'disableSystemAnimations', 'disables system animations on the connected device', SystemAnimations) {
-            enable = false
-        }
         configureDemoMode(project, extension.demoModeContainer)
+        configureSystemAnimations(project)
 
-        project.tasks.withType(AdbTask) { task ->
-            extension.attachDefaults(task)
-        }
-    }
-
-    private void configureDemoMode(Project project, demoModeContainer) {
-        project.tasks.create('enableDemoMode', EnableDemoModeTask) {
-            commands = demoModeContainer
-        }
-        project.tasks.create('disableDemoMode', DisableDemoModeTask)
+        attachDefaults(project, extension)
     }
 
     private configureInputScripts(AndroidCommandPluginExtension command, Project project) {
@@ -60,6 +46,13 @@ class AndroidCommandPlugin implements Plugin<Project> {
         }
     }
 
+    private void configureDemoMode(Project project, demoModeContainer) {
+        project.tasks.create('enableDemoMode', EnableDemoModeTask) {
+            commands = demoModeContainer
+        }
+        project.tasks.create('disableDemoMode', DisableDemoModeTask)
+    }
+
     private static configureInstallTasks(AndroidCommandPluginExtension command, Project project) {
         def factory = new InstallTaskFactory(project)
         project.android.applicationVariants.all { variant ->
@@ -69,12 +62,18 @@ class AndroidCommandPlugin implements Plugin<Project> {
             factory.create(variant, new InstallExtension('device', 'installs the APK on the specified device'))
         }
     }
-    
-    static defaultTask(Project project, String taskName, String description, Class<? extends AdbTask> taskType, Closure configuration) {
-        AdbTask task = project.tasks.create(taskName, taskType)
-        task.configure configuration
-        task.group = TASK_GROUP
-        task.description = description
+
+    private void configureSystemAnimations(Project project) {
+        project.tasks.create('enableSystemAnimations', SystemAnimations) { enable = true }
+        project.tasks.create('disableSystemAnimations', SystemAnimations) { enable = false }
+    }
+
+    private static DomainObjectCollection<AdbTask> attachDefaults(Project project, extension) {
+        project.tasks.withType(AdbTask) { task ->
+            task.conventionMapping.adb = { extension.adb }
+            task.conventionMapping.aapt = { extension.aapt }
+            task.conventionMapping.deviceId = { extension.deviceId }
+        }
     }
 
 }

--- a/plugin/src/main/groovy/com/novoda/gradle/command/AndroidCommandPluginExtension.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/AndroidCommandPluginExtension.groovy
@@ -90,12 +90,6 @@ public class AndroidCommandPluginExtension {
         install.execute(installContainer)
     }
 
-    void attachDefaults(AdbTask task) {
-        task.conventionMapping.adb = { getAdb() }
-        task.conventionMapping.aapt = { getAapt() }
-        task.conventionMapping.deviceId = { getDeviceId() }
-    }
-
     List<Device> devices() {
         deviceIds().collect { deviceId ->
             new Device(getAdb(), deviceId)

--- a/plugin/src/main/groovy/com/novoda/gradle/command/DisableDemoModeTask.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/DisableDemoModeTask.groovy
@@ -8,7 +8,7 @@ class DisableDemoModeTask extends AdbTask {
 
     DisableDemoModeTask() {
         this.group = AndroidCommandPlugin.TASK_GROUP
-        this.description = "Disables demo mode on the device"
+        this.description = 'Disables demo mode on the device'
     }
 
     @TaskAction

--- a/plugin/src/main/groovy/com/novoda/gradle/command/EnableDemoModeTask.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/EnableDemoModeTask.groovy
@@ -11,7 +11,7 @@ class EnableDemoModeTask extends AdbTask {
 
     EnableDemoModeTask() {
         this.group = AndroidCommandPlugin.TASK_GROUP
-        this.description = "Enables demo mode on the device"
+        this.description = 'Enables demo mode on the device'
     }
 
     @TaskAction

--- a/plugin/src/main/groovy/com/novoda/gradle/command/Files.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/Files.groovy
@@ -34,8 +34,6 @@ class Files extends AdbTask {
     }
 
     private String adb(String... params) {
-        def adb = getAdb() ?: resolveFromExtension('adb')
-        def deviceId = getDeviceId() ?: resolveFromExtension('deviceId')
         AdbCommand adbCommand = [adb: adb, deviceId: deviceId, parameters: params as List ]
         adbCommand.execute().text
     }

--- a/plugin/src/main/groovy/com/novoda/gradle/command/Run.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/Run.groovy
@@ -22,7 +22,6 @@ class Run extends AdbTask {
             // https://code.google.com/p/android/issues/detail?id=157150
             logger.info 'no launchable-activity found, falling back to parsing the manifest'
 
-            def aapt = this.aapt ?: resolveFromExtension('aapt')
             output = [aapt, 'dump', 'xmltree', apkPath, 'AndroidManifest.xml'].execute().text
 
             def it = output.readLines().iterator()

--- a/plugin/src/main/groovy/com/novoda/gradle/command/SystemAnimations.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/SystemAnimations.groovy
@@ -8,6 +8,11 @@ class SystemAnimations extends AdbTask {
 
     boolean enable
 
+    SystemAnimations() {
+        this.group = AndroidCommandPlugin.TASK_GROUP
+        this.description = "${enable ? 'Enables' : 'Disables'} system animations on the device"
+    }
+
     @TaskAction
     void exec() {
         assertDeviceConnected()


### PR DESCRIPTION
This PR cleans-up and removed old deprecated methods. 
Last year we didn't like that the tasks are aware of the extension. Instead, Plugin should use the extension to create tasks. For this we already started to use `conventionMapping` to lazily connect the tasks and extension without the knowledge of the 2 each other.
