### PR TITLE
Start and Run scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,9 +164,9 @@ install {
 
 ### Start
 
-`start<Variant>` and `run<Variant>` tasks are available by default. Start tasks just start and already installed application. Run tasks first install the app before starting.
+`start<Variant>` and `run<Variant>` tasks are available by default. Start tasks just start an already installed application. Run tasks first install the app before starting.
  
-Just like `install` dsl, it is possible specify device id. Doing this will create corresponding `start` and `run` tasks. 
+Just like the `install` dsl, it is possible to specify a device id. Doing this will create corresponding `start` and `run` tasks. 
 
 ```groovy
 start {

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Here is how you can install on a specific device using `deviceId`
 
 ```groovy
 install {
-    toNewestDevice {
+    onNewestDevice {
         deviceId {
             def device = devices().max { it.sdkVersion() }
             device.id
@@ -161,6 +161,28 @@ install {
     }
 }
 ```
+
+### Start
+
+`start<Variant>` and `run<Variant>` tasks are available by default. Start tasks just start and already installed application. Run tasks first install the app before starting.
+ 
+Just like `install` dsl, it is possible specify device id. Doing this will create corresponding `start` and `run` tasks. 
+
+```groovy
+start {
+    amazon {
+        deviceId {
+            def kindle = devices().find { it.brand() == 'Amazon' }
+            if (!kindle) {
+                throw new GroovyRuntimeException('No Amazon device found')
+            }
+            kindle.id
+        }
+    }
+}
+``` 
+
+This configuration creates `startAmazon<Variant>` and `runAmazon<Variant>` tasks.
 
 Links
 -----

--- a/plugin/src/main/groovy/com/novoda/gradle/command/AndroidCommandPlugin.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/AndroidCommandPlugin.groovy
@@ -17,9 +17,8 @@ class AndroidCommandPlugin implements Plugin<Project> {
         AndroidCommandPluginExtension extension = project.android.extensions.create('command', AndroidCommandPluginExtension, project)
 
         configureInstallTasks(extension, project)
+        configureStartTasks(extension, project)
 
-        extension.task 'run', 'installs and runs a APK on the specified device', Run, ['installDevice']
-        extension.task 'start', 'runs an already installed APK on the specified device', Run
         extension.task 'stop', 'forcibly stops the app on the specified device', Stop
         extension.task 'clearPrefs', 'clears the shared preferences on the specified device', ClearPreferences
         extension.task 'uninstallDevice', 'uninstalls the APK from the specific device', Uninstall
@@ -59,7 +58,17 @@ class AndroidCommandPlugin implements Plugin<Project> {
             command.installContainer.all { extension ->
                 factory.create(variant, extension)
             }
-            factory.create(variant, new InstallExtension('device', 'installs the APK on the specified device'))
+            factory.create(variant, new InstallExtension('device'))
+        }
+    }
+
+    private static configureStartTasks(AndroidCommandPluginExtension command, Project project) {
+        def factory = new RunTaskFactory(project)
+        project.android.applicationVariants.all { variant ->
+            command.startContainer.all { extension ->
+                factory.create(variant, extension)
+            }
+            factory.create(variant)
         }
     }
 

--- a/plugin/src/main/groovy/com/novoda/gradle/command/AndroidCommandPluginExtension.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/AndroidCommandPluginExtension.groovy
@@ -18,6 +18,7 @@ public class AndroidCommandPluginExtension {
     final NamedDomainObjectContainer<InputExtension> scriptsContainer
     final NamedDomainObjectContainer<DemoModeExtension> demoModeContainer
     final NamedDomainObjectContainer<InstallExtension> installContainer
+    final NamedDomainObjectContainer<RunExtension> startContainer
 
     AndroidCommandPluginExtension(Project project) {
         this(project, findAndroidHomeFrom(project.android))
@@ -30,6 +31,7 @@ public class AndroidCommandPluginExtension {
         this.demoModeContainer = project.container(DemoModeExtension)
         this.scriptsContainer = project.container(InputExtension)
         this.installContainer = project.container(InstallExtension)
+        this.startContainer = project.container(RunExtension)
     }
 
     def task(String name, Class<? extends AdbTask> type, Closure configuration) {
@@ -82,12 +84,16 @@ public class AndroidCommandPluginExtension {
         action.execute(demoModeContainer)
     }
 
-    void scripts(Action<NamedDomainObjectContainer<InputExtension>> script) {
-        script.execute(scriptsContainer)
+    void scripts(Action<NamedDomainObjectContainer<InputExtension>> action) {
+        action.execute(scriptsContainer)
     }
 
-    void install(Action<NamedDomainObjectContainer<InstallExtension>> install) {
-        install.execute(installContainer)
+    void install(Action<NamedDomainObjectContainer<InstallExtension>> action) {
+        action.execute(installContainer)
+    }
+    
+    void start(Action<NamedDomainObjectContainer<RunExtension>> action) {
+        action.execute(startContainer)
     }
 
     List<Device> devices() {

--- a/plugin/src/main/groovy/com/novoda/gradle/command/DescriptionAware.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/DescriptionAware.groovy
@@ -1,0 +1,10 @@
+package com.novoda.gradle.command;
+
+trait DescriptionAware {
+
+    String description
+
+    void description(String description) {
+        this.description = description
+    }
+}

--- a/plugin/src/main/groovy/com/novoda/gradle/command/DeviceAware.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/DeviceAware.groovy
@@ -1,6 +1,6 @@
 package com.novoda.gradle.command;
 
-class DeviceAwareExtension {
+trait DeviceAware {
 
     def deviceId
     

--- a/plugin/src/main/groovy/com/novoda/gradle/command/DeviceAwareExtension.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/DeviceAwareExtension.groovy
@@ -1,0 +1,10 @@
+package com.novoda.gradle.command;
+
+class DeviceAwareExtension {
+
+    def deviceId
+    
+    void deviceId(deviceId) {
+        this.deviceId = deviceId
+    }
+}

--- a/plugin/src/main/groovy/com/novoda/gradle/command/Install.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/Install.groovy
@@ -25,8 +25,9 @@ class Install extends AdbTask {
     @TaskAction
     void exec() {
         def arguments = ['install']
-        if (resolveCustomFlags())
+        if (resolveCustomFlags()) {
             arguments += resolveCustomFlags()
+        }
 
         arguments += ['-r', apkPath]
 

--- a/plugin/src/main/groovy/com/novoda/gradle/command/InstallExtension.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/InstallExtension.groovy
@@ -1,9 +1,8 @@
 package com.novoda.gradle.command
 
-final class InstallExtension extends DeviceAwareExtension {
+final class InstallExtension implements DeviceAware, DescriptionAware {
 
     String name
-    String description
     def customFlags
 
     InstallExtension(name, description = null) {
@@ -15,7 +14,4 @@ final class InstallExtension extends DeviceAwareExtension {
         this.customFlags = customFlags
     }
 
-    void description(String description) {
-        this.description = description
-    }
 }

--- a/plugin/src/main/groovy/com/novoda/gradle/command/InstallTaskFactory.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/InstallTaskFactory.groovy
@@ -15,13 +15,8 @@ class InstallTaskFactory {
     }
 
     def create(variant, InstallExtension extension) {
-        variantAwareTaskFactory.create(
-                variant: variant,
-                taskName: "install${extension.name.capitalize()}",
-                taskType: Install,
-                dependsOn: 'assemble'
-        ).configure {
-            description = VariantAwareDescription.createFor(variant, extension, DEFAULT_DESCRIPTION)
+        variantAwareTaskFactory.create(variant, "install${extension.name.capitalize()}", Install, 'assemble').configure {
+            description = VariantAwareDescription.descriptionFor(variant, extension, DEFAULT_DESCRIPTION)
             group = 'install'
             installExtension = extension
             conventionMapping.deviceId = { extension.deviceId }

--- a/plugin/src/main/groovy/com/novoda/gradle/command/InstallTaskFactory.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/InstallTaskFactory.groovy
@@ -5,8 +5,8 @@ import org.gradle.api.Project
 class InstallTaskFactory {
 
     private static final String DEFAULT_DESCRIPTION = 'installs the APK on the specified device'
-    
-    final Project project
+
+    private final Project project
     private final VariantAwareTaskFactory<Install> variantAwareTaskFactory
 
     InstallTaskFactory(Project project) {
@@ -14,22 +14,18 @@ class InstallTaskFactory {
         this.variantAwareTaskFactory = new VariantAwareTaskFactory<>(project)
     }
 
-    Install create(variant, InstallExtension extension) {
-        Install task = variantAwareTaskFactory.create(variant, "install${extension.name.capitalize()}", Install, 'assemble')
-
-        task.group = 'install'
-        task.installExtension = extension
-
-        task.description = descriptionFor(variant, extension, DEFAULT_DESCRIPTION)
-        if (extension.deviceId) {
-            task.conventionMapping.deviceId = { extension.deviceId }
+    def create(variant, InstallExtension extension) {
+        variantAwareTaskFactory.create(
+                variant: variant,
+                taskName: "install${extension.name.capitalize()}",
+                taskType: Install,
+                dependsOn: 'assemble'
+        ).configure {
+            description = VariantAwareDescription.createFor(variant, extension, DEFAULT_DESCRIPTION)
+            group = 'install'
+            installExtension = extension
+            conventionMapping.deviceId = { extension.deviceId }
         }
-        task
     }
 
-    private static String descriptionFor(variant, InstallExtension extension, String defaultDescription) {
-        def variantName = VariantSuffix.variantNameFor(variant)
-        def description = extension.description ?: defaultDescription
-        return "$description for $variantName"
-    }
 }

--- a/plugin/src/main/groovy/com/novoda/gradle/command/RunExtension.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/RunExtension.groovy
@@ -1,18 +1,13 @@
 package com.novoda.gradle.command
 
-final class InstallExtension extends DeviceAwareExtension {
+final class RunExtension extends DeviceAwareExtension {
 
     String name
     String description
-    def customFlags
 
-    InstallExtension(name, description = null) {
+    RunExtension(name = null, description = null) {
         this.name = name
         this.description = description
-    }
-
-    void customFlags(customFlags) {
-        this.customFlags = customFlags
     }
 
     void description(String description) {

--- a/plugin/src/main/groovy/com/novoda/gradle/command/RunExtension.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/RunExtension.groovy
@@ -1,16 +1,11 @@
 package com.novoda.gradle.command
 
-final class RunExtension extends DeviceAwareExtension {
+final class RunExtension implements DeviceAware, DescriptionAware {
 
     String name
-    String description
 
     RunExtension(name = null, description = null) {
         this.name = name
-        this.description = description
-    }
-
-    void description(String description) {
         this.description = description
     }
 }

--- a/plugin/src/main/groovy/com/novoda/gradle/command/RunTaskFactory.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/RunTaskFactory.groovy
@@ -1,0 +1,43 @@
+package com.novoda.gradle.command
+
+import org.gradle.api.Project
+
+class RunTaskFactory {
+
+    final Project project
+    private final VariantAwareTaskFactory<Run> variantAwareTaskFactory
+
+    RunTaskFactory(Project project) {
+        this.project = project
+        this.variantAwareTaskFactory = new VariantAwareTaskFactory<>(project)
+    }
+
+    def create(variant, RunExtension extension = new RunExtension()) {
+        def extensionSuffix = extension.name ? extension.name.capitalize() : ''
+
+        variantAwareTaskFactory.create(variant,
+                taskName: "run${extensionSuffix}",
+                taskType: Run,
+                dependsOn: 'installDevice'
+        ).configure {
+            group = 'start'
+            conventionMapping.deviceId = { extension.deviceId }
+            description = descriptionFor(variant, extension, 'installs and runs APK on the specified device')
+        }
+        
+        variantAwareTaskFactory.create(variant,
+                taskName: "start${extensionSuffix}",
+                taskType: Run
+        ).configure {
+            group = 'start'
+            conventionMapping.deviceId = { extension.deviceId }
+            description = descriptionFor(variant, extension, 'runs an already installed APK on the specified device')
+        }
+    }
+
+    private static String descriptionFor(variant, RunExtension extension, String defaultDescription) {
+        def variantName = VariantSuffix.variantNameFor(variant)
+        def description = extension.description ?: defaultDescription
+        return "$description for $variantName"
+    }
+}

--- a/plugin/src/main/groovy/com/novoda/gradle/command/RunTaskFactory.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/RunTaskFactory.groovy
@@ -4,6 +4,9 @@ import org.gradle.api.Project
 
 class RunTaskFactory {
 
+    private static final String RUN_DEFAULT_DESCRIPTION = 'installs and runs APK on the specified device'
+    private static final String START_DEFAULT_DESCRIPTION = 'runs an already installed APK on the specified device'
+
     private final Project project
     private final VariantAwareTaskFactory<Run> variantAwareTaskFactory
 
@@ -15,25 +18,14 @@ class RunTaskFactory {
     def create(variant, RunExtension extension = new RunExtension()) {
         def extensionSuffix = extension.name ? extension.name.capitalize() : ''
 
-        variantAwareTaskFactory.create(
-                variant: variant,
-                taskName: "run${extensionSuffix}",
-                taskType: Run,
-                dependsOn: 'installDevice'
-        ).configure {
-            description = VariantAwareDescription.createFor(variant, extension,
-                    defaultDescription: 'installs and runs APK on the specified device')
+        variantAwareTaskFactory.create(variant, "run${extensionSuffix}", Run, 'installDevice').configure {
+            description = VariantAwareDescription.descriptionFor(variant, extension, RUN_DEFAULT_DESCRIPTION)
             group = 'start'
             conventionMapping.deviceId = { extension.deviceId }
         }
 
-        variantAwareTaskFactory.create(
-                variant: variant,
-                taskName: "start${extensionSuffix}",
-                taskType: Run
-        ).configure {
-            description = VariantAwareDescription.createFor(variant, extension,
-                    defaultDescription: 'runs an already installed APK on the specified device')
+        variantAwareTaskFactory.create(variant, "start${extensionSuffix}", Run).configure {
+            description = VariantAwareDescription.descriptionFor(variant, extension, START_DEFAULT_DESCRIPTION)
             group = 'start'
             conventionMapping.deviceId = { extension.deviceId }
         }

--- a/plugin/src/main/groovy/com/novoda/gradle/command/RunTaskFactory.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/RunTaskFactory.groovy
@@ -4,7 +4,7 @@ import org.gradle.api.Project
 
 class RunTaskFactory {
 
-    final Project project
+    private final Project project
     private final VariantAwareTaskFactory<Run> variantAwareTaskFactory
 
     RunTaskFactory(Project project) {
@@ -15,29 +15,28 @@ class RunTaskFactory {
     def create(variant, RunExtension extension = new RunExtension()) {
         def extensionSuffix = extension.name ? extension.name.capitalize() : ''
 
-        variantAwareTaskFactory.create(variant,
+        variantAwareTaskFactory.create(
+                variant: variant,
                 taskName: "run${extensionSuffix}",
                 taskType: Run,
                 dependsOn: 'installDevice'
         ).configure {
+            description = VariantAwareDescription.createFor(variant, extension,
+                    defaultDescription: 'installs and runs APK on the specified device')
             group = 'start'
             conventionMapping.deviceId = { extension.deviceId }
-            description = descriptionFor(variant, extension, 'installs and runs APK on the specified device')
         }
-        
-        variantAwareTaskFactory.create(variant,
+
+        variantAwareTaskFactory.create(
+                variant: variant,
                 taskName: "start${extensionSuffix}",
                 taskType: Run
         ).configure {
+            description = VariantAwareDescription.createFor(variant, extension,
+                    defaultDescription: 'runs an already installed APK on the specified device')
             group = 'start'
             conventionMapping.deviceId = { extension.deviceId }
-            description = descriptionFor(variant, extension, 'runs an already installed APK on the specified device')
         }
     }
 
-    private static String descriptionFor(variant, RunExtension extension, String defaultDescription) {
-        def variantName = VariantSuffix.variantNameFor(variant)
-        def description = extension.description ?: defaultDescription
-        return "$description for $variantName"
-    }
 }

--- a/plugin/src/main/groovy/com/novoda/gradle/command/VariantAwareDescription.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/VariantAwareDescription.groovy
@@ -9,7 +9,7 @@ class VariantAwareDescription {
 
     private VariantAwareDescription() {}
 
-    static String createFor(variant, extension, String defaultDescription = null) {
+    static String descriptionFor(variant, extension, String defaultDescription = null) {
         def variantName = VariantSuffix.variantNameFor(variant)
         def description = extension instanceof DescriptionAware && extension.description ?: defaultDescription
         return description ? "$description for $variantName" : null

--- a/plugin/src/main/groovy/com/novoda/gradle/command/VariantAwareDescription.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/VariantAwareDescription.groovy
@@ -1,0 +1,17 @@
+package com.novoda.gradle.command
+
+import groovy.transform.CompileStatic
+import groovy.transform.PackageScope
+
+@PackageScope
+@CompileStatic
+class VariantAwareDescription {
+
+    private VariantAwareDescription() {}
+
+    static String createFor(variant, extension, String defaultDescription = null) {
+        def variantName = VariantSuffix.variantNameFor(variant)
+        def description = extension instanceof DescriptionAware && extension.description ?: defaultDescription
+        return description ? "$description for $variantName" : null
+    }
+}

--- a/plugin/src/main/groovy/com/novoda/gradle/command/VariantAwareTaskFactory.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/VariantAwareTaskFactory.groovy
@@ -2,7 +2,7 @@ package com.novoda.gradle.command
 
 import org.gradle.api.Project
 
-class VariantAwareTaskFactory<T extends AdbTask> {
+final class VariantAwareTaskFactory<T extends AdbTask> {
 
     final Project project
 

--- a/plugin/src/main/groovy/com/novoda/gradle/command/VariantAwareTaskFactory.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/VariantAwareTaskFactory.groovy
@@ -10,7 +10,7 @@ class VariantAwareTaskFactory<T extends AdbTask> {
         this.project = project
     }
 
-    T create(variant, String taskName, Class<T> taskType, String dependsOn) {
+    T create(variant, String taskName, Class<T> taskType, String dependsOn = null) {
         def variantName = VariantSuffix.variantNameFor(variant)
         T task = project.tasks.create("$taskName$variantName", taskType)
 

--- a/plugin/src/main/groovy/com/novoda/gradle/command/VariantAwareTaskFactory.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/VariantAwareTaskFactory.groovy
@@ -1,0 +1,23 @@
+package com.novoda.gradle.command
+
+import org.gradle.api.Project
+
+class VariantAwareTaskFactory<T extends AdbTask> {
+
+    final Project project
+
+    VariantAwareTaskFactory(Project project) {
+        this.project = project
+    }
+
+    T create(variant, String taskName, Class<T> taskType, String dependsOn) {
+        def variantName = VariantSuffix.variantNameFor(variant)
+        T task = project.tasks.create("$taskName$variantName", taskType)
+
+        if (dependsOn) {
+            task.dependsOn "$dependsOn$variantName"
+        }
+        task.apkPath = "${-> variant.outputs[0].outputFile}"
+        task
+    }
+}

--- a/sample/app/build.gradle
+++ b/sample/app/build.gradle
@@ -51,24 +51,7 @@ android {
             categories 'android.intent.category.ONLY_ME', 'android.intent.category.MONKEY'
         }
         sortBySubtasks false
-
-        task('runAmazon', com.novoda.gradle.command.Run) {
-            deviceId {
-                def kindle = devices().find { it.brand() == 'Amazon' }
-                if (!kindle) {
-                    throw new GroovyRuntimeException('No Amazon device found')
-                }
-                kindle.id
-            }
-        }
-
-        task('runNewest', com.novoda.gradle.command.Run, ['installDevice']) {
-            deviceId {
-                def device = devices().max { it.sdkVersion() }
-                device.id
-            }
-        }
-
+        
         // More info: https://github.com/novoda/gradle-android-command-plugin#input-scripting
         scripts {
             autoLogin {
@@ -110,7 +93,7 @@ android {
                 customFlags = ['-d']
             }
 
-            toNewestDevice {
+            onNewestDevice {
                 deviceId {
                     def device = devices().max { it.sdkVersion() }
                     device.id
@@ -120,17 +103,37 @@ android {
             currentUser.customFlags = ['--user', 'current']
         }
 
-        task listDevices doLast {
-            println()
-            println 'Attached devices:'
-            devices().each {
-                println it
+        // More info: https://github.com/novoda/gradle-android-command-plugin#start
+        start {
+            amazon {
+                deviceId {
+                    def kindle = devices().find { it.brand() == 'Amazon' }
+                    if (!kindle) {
+                        throw new GroovyRuntimeException('No Amazon device found')
+                    }
+                    kindle.id
+                }
+            }
+
+            onNewestDevice {
+                deviceId {
+                    def device = devices().max { it.sdkVersion() }
+                    device.id
+                }
             }
         }
-
-        task dumpActivityStack(type: com.novoda.gradle.command.ActivityStack) {
-        }
     }
+}
+
+task listDevices doLast {
+    println()
+    println 'Attached devices:'
+    android.command.devices().each {
+        println it
+    }
+}
+
+task dumpActivityStack(type: com.novoda.gradle.command.ActivityStack) {
 }
 
 /**


### PR DESCRIPTION
Just like `Install` script, this PR introduces `start` closure to create `run` and `start` tasks.

To be able to share some functionality across extensions, `DeviceAware` and `DescriptionAware` are introduced. They are `trait`s which allows us to have implementation in interfaces in groovy.

`VariantAwareTaskFactory` is created to be able to create tasks that will attach variant name to tasks names and dependency names. 

Thanks to this, `InstallTaskFactory` and `RunTaskFactory` are simpler. 

Examples are modified to use new dsl. Together with this, we don't have any manual task creation inside `command` extension. It is of course fine to create custom tasks manually but all those examples are now outside of `command` closure.