### PR TITLE
fix broken deviceId resolution 

### DIFF
--- a/plugin/src/main/groovy/com/novoda/gradle/command/InstallTaskFactory.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/InstallTaskFactory.groovy
@@ -19,7 +19,6 @@ class InstallTaskFactory {
             description = VariantAwareDescription.descriptionFor(variant, extension, DEFAULT_DESCRIPTION)
             group = 'install'
             installExtension = extension
-            conventionMapping.deviceId = { extension.deviceId }
         }
     }
 

--- a/plugin/src/main/groovy/com/novoda/gradle/command/RunTaskFactory.groovy
+++ b/plugin/src/main/groovy/com/novoda/gradle/command/RunTaskFactory.groovy
@@ -21,13 +21,11 @@ class RunTaskFactory {
         variantAwareTaskFactory.create(variant, "run${extensionSuffix}", Run, 'installDevice').configure {
             description = VariantAwareDescription.descriptionFor(variant, extension, RUN_DEFAULT_DESCRIPTION)
             group = 'adb start'
-            conventionMapping.deviceId = { extension.deviceId }
         }
 
         variantAwareTaskFactory.create(variant, "start${extensionSuffix}", Run).configure {
             description = VariantAwareDescription.descriptionFor(variant, extension, START_DEFAULT_DESCRIPTION)
             group = 'adb start'
-            conventionMapping.deviceId = { extension.deviceId }
         }
     }
 


### PR DESCRIPTION
Fixes #138 

In the latest version (`2.0`) we introduced a bug within the device id resolution that resulted in `install` and `run` tasks to fail with an exception. 

We fix this here by removing the default mappings for the device-id within the task factories for install and run. 

This change means that `deviceId` can not be overridden within `install`, `start` or `run` configuration closures (it can still be set within the `command` closure). 
Hopefully, this functionality can be re-enabled following up.