### PR TITLE
Update release scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 2.1.0
 
-_2019-05-02_
+_2019-05-05_
 
 Support Task Configuration Avoidance from Gradle 5. Thanks to this support, it is now zero overhead to add the Android Command Plugin. Plugin's tasks will not be eagerly configured unless they are explicitly run.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 gradle-android-command-plugin
 =============================
-[![](https://ci.novoda.com/buildStatus/icon?job=gradle-android-command-plugin)](https://ci.novoda.com/job/gradle-android-command-plugin/lastSuccessfulBuild/console) [![](https://raw.githubusercontent.com/novoda/novoda/master/assets/btn_apache_lisence.png)](LICENSE.txt) [![Bintray](https://api.bintray.com/packages/novoda/maven/gradle-android-command-plugin/images/download.svg) ](https://bintray.com/novoda/maven/gradle-android-command-plugin/_latestVersion)
+[![](https://ci.novoda.com/buildStatus/icon?job=gradle-android-command-plugin)](https://ci.novoda.com/job/gradle-android-command-plugin/lastSuccessfulBuild/console) [![](https://raw.githubusercontent.com/novoda/novoda/master/assets/btn_apache_lisence.png)](LICENSE.txt) [![Bintray](https://api.bintray.com/packages/novoda-oss/maven/gradle-android-command-plugin/images/download.svg) ](https://bintray.com/novoda-oss/maven/gradle-android-command-plugin/_latestVersion)
 
 Use gradle tasks to run specific `adb` commands.
 
@@ -238,6 +238,21 @@ start {
 ``` 
 
 This configuration creates `startAmazon<Variant>` and `runAmazon<Variant>` tasks.
+
+## Snapshots
+[![CI status](https://ci.novoda.com/buildStatus/icon?job=gradle-android-command-plugin)](https://ci.novoda.com/job/gradle-android-command-plugin/lastBuild/console) [![Download from Bintray](https://api.bintray.com/packages/novoda-oss/snapshots/gradle-android-command-plugin/images/download.svg)](https://bintray.com/novoda-oss/snapshots/gradle-android-command-plugin/_latestVersion)
+
+Snapshot builds from [`develop`](https://github.com/novoda/gradle-android-command-plugin/compare/master...develop) are automatically deployed to a [repository](https://bintray.com/novoda-oss/snapshots/gradle-android-command-plugin/_latestVersion) that is **not** synced with JCenter.
+To consume a snapshot build add an additional maven repo as follows:
+```
+repositories {
+    maven {
+        url 'https://dl.bintray.com/novoda-oss/snapshots/'
+    }
+}
+```
+
+You can find the latest snapshot version following this [link](https://bintray.com/novoda-oss/snapshots/gradle-android-command-plugin/_latestVersion).
 
 Links
 -----

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,12 @@
+buildscript {
+    repositories {
+        jcenter()
+    }
+    dependencies {
+        classpath 'com.novoda:bintray-release:0.9.1'
+    }
+}
+
 wrapper {
     gradleVersion = '4.10.3'
     distributionUrl = "https://services.gradle.org/distributions/gradle-${gradleVersion}-all.zip"

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
+        classpath 'com.novoda:gradle-build-properties-plugin:0.4.1'
         classpath 'com.novoda:bintray-release:0.9.1'
     }
 }

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -1,12 +1,3 @@
-buildscript {
-    repositories {
-        jcenter()
-    }
-    dependencies {
-        classpath 'com.novoda:bintray-release:0.4.0'
-    }
-}
-
 apply plugin: 'groovy'
 apply plugin: 'com.novoda.bintray-release'
 

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -1,5 +1,5 @@
 apply plugin: 'groovy'
-apply plugin: 'com.novoda.bintray-release'
+apply from: 'publish.gradle'
 
 repositories {
     mavenCentral()
@@ -8,16 +8,4 @@ repositories {
 dependencies {
     compile gradleApi()
     testCompile 'junit:junit:4.12'
-}
-
-group = 'com.novoda'
-version = '2.1.0'
-
-publish {
-    userOrg = 'novoda'
-    groupId = 'com.novoda'
-    artifactId = 'gradle-android-command-plugin'
-    publishVersion = project.version
-    desc = 'Useful tasks for gradle android builds'
-    website = 'https://github.com/novoda/gradle-android-command-plugin'
 }

--- a/plugin/publish.gradle
+++ b/plugin/publish.gradle
@@ -1,0 +1,56 @@
+apply plugin: 'com.novoda.build-properties'
+apply plugin: 'com.novoda.bintray-release'
+
+version = '2.1.0'
+
+buildProperties {
+    cli {
+        using(project)
+    }
+
+    bintray {
+        using(bintrayCredentials()).or(cli)
+        description = '''This should contain the following properties:
+                       - bintrayOrg: name of the Bintray organisation to deploy the artifacts to
+                       - bintrayRepo: name of the repo of the organisation to deploy the artifacts to
+                       - bintrayUser: name of the account used to deploy the artifacts
+                       - bintrayKey: API key of the account used to deploy the artifacts
+        '''.stripIndent()
+    }
+
+    publish {
+        using(['version': "${generateVersion()}"]).or(project.buildProperties.bintray)
+    }
+}
+
+publish {
+    groupId = 'com.novoda'
+    artifactId = 'gradle-android-command-plugin'
+    desc = 'Useful tasks for gradle android builds'
+    website = 'https://github.com/novoda/gradle-android-command-plugin'
+
+    version = project.buildProperties.publish['version'].string
+    publishVersion = project.buildProperties.publish['version'].string
+    bintrayUser = project.buildProperties.publish['bintrayUser'].string
+    bintrayKey = project.buildProperties.publish['bintrayKey'].string
+    repoName = project.buildProperties.publish['bintrayRepo'].string
+    userOrg = project.buildProperties.publish['bintrayOrg'].string
+}
+
+def bintrayCredentials() {
+    return isDryRun() ?
+            ['bintrayOrg': 'n/a', 'bintrayRepo': 'n/a', 'bintrayUser': 'n/a', 'bintrayKey': 'n/a'] :
+            new File("${System.getenv('BINTRAY_PROPERTIES')}")
+}
+
+def generateVersion() {
+    return isSnapshot() ? "DEVELOP-${System.getenv('BUILD_NUMBER') ?: 'LOCAL'}" : project.version
+}
+
+boolean isDryRun() {
+    project.buildProperties.cli['dryRun'].or(true).boolean
+}
+
+boolean isSnapshot() {
+    project.buildProperties.cli['bintraySnapshot'].or(false).boolean
+}


### PR DESCRIPTION
This PR improve the release setup in order to be in line with the other open source libraries in Novoda. It also adds support for snapshot releases (automatically deployed every time a PR against `develop` is merged).